### PR TITLE
Dependencies: Use Version Numbers Instead of '*'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,8 +2,8 @@
 name = "cargo-outdated"
 version = "0.1.0"
 dependencies = [
- "ansi_term 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tabwriter 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -21,15 +21,15 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.5.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "1.0.0"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ansi_term 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.1.0"
 authors = ["Kevin K. <kbknapp@gmail.com>"]
 
 [dependencies]
-clap = "*"
-toml = "*"
-semver = "*"
-tabwriter = "*"
-tempdir = "*"
+clap = "1.1"
+toml = "0.1"
+semver = "0.1"
+tabwriter = "0.1"
+tempdir = "0.3"
 
 [dependencies.ansi_term]
-version = "*"
+version = "0.6"
 optional = true
 
 [features]


### PR DESCRIPTION
I consider Using `*` to be a bad practice since it 'skips' SemVer and only works based on pure luck :)

(There's even a [RFC](https://github.com/rust-lang/rfcs/pull/1241) to not allow `*` for crates.io crates.)