### PR TITLE
Include children of non-registry dependencies

### DIFF
--- a/src/deps/dep.rs
+++ b/src/deps/dep.rs
@@ -1,6 +1,7 @@
 #[derive(Debug)]
 pub struct Dep {
     pub name: String,
+    pub source: String,
     pub project_ver: String,
     pub semver_ver: Option<String>,
     pub latest_ver: Option<String>,


### PR DESCRIPTION
Traverse all dependencies when building the dependency tree, and don't prune non-registry dependencies until the final step.  This fixes the output for projects like servo that are split into several crates in a single repo, with path dependencies between them.