### PR TITLE
chore: use LTO (Link Time Optimization)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ nightly = []
 unstable = ["lints"]
 lints = ["clippy", "nightly"]
 travis = ["nightly", "lints"]
+
+[profile.release]
+lto = true


### PR DESCRIPTION
with Link Time Optimization, `cargo-outdated`'s binary size can reduce about 3% (on my Linux)