### PR TITLE
Remove clippy dependency and unstable features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,6 @@ version = "0.2.0"
 dependencies = [
  "ansi_term 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tabwriter 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -35,18 +34,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clippy"
-version = "0.0.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quine-mc_cluskey 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,22 +44,12 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "quine-mc_cluskey"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "rand"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-serialize"
@@ -117,11 +94,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,3 +103,18 @@ name = "vec_map"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[metadata]
+"checksum ansi_term 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1f46cd5b1d660c938e3f92dfe7a73d832b3281479363dd0cd9c1c2fbf60f7962"
+"checksum bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4f67931368edf3a9a51d29886d245f1c3db2f1ef0dcc9e35ff70341b78c10d23"
+"checksum clap 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "552313dfcbc7e59551c660c4a0ff24543656ffc1fb3b8e2dc96ad776328810fd"
+"checksum libc 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c96061f0c8a2dc27482e394d82e23073569de41d73cd736672ccd3e5c7471bfd"
+"checksum nom 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6caab12c5f97aa316cb249725aa32115118e1522b445e26c257dd77cad5ffd4e"
+"checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
+"checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
+"checksum semver 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d5b7638a1f03815d94e88cb3b3c08e87f0db4d683ef499d1836aaf70a45623f"
+"checksum strsim 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0d5f575d5ced6634a5c4cb842163dab907dc7e9148b28dc482d81b8855cbe985"
+"checksum tabwriter 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "85dbf563da2891d55ef4b00ef08c5b5f160143f67691ff1f97ad89e77824ed3b"
+"checksum tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0b62933a3f96cd559700662c34f8bab881d9e3540289fb4f368419c7f13a5aa9"
+"checksum toml 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "fcd27a04ca509aff336ba5eb2abc58d456f52c4ff64d9724d88acb85ead560b6"
+"checksum unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6722facc10989f63ee0e20a83cd4e1714a9ae11529403ac7e0afd069abc39e"
+"checksum vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cac5efe5cb0fa14ec2f84f83c701c562ee63f6dcc680861b21d65c682adfb05f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,16 +19,13 @@ semver = "0.2"
 tabwriter = "0.1"
 tempdir = "0.3"
 ansi_term = {version = "0.7", optional = true}
-clippy = {version = "=0.0.64", optional = true}
 
 [features]
 default = ["color"]
 color = ["ansi_term"]
 debug = []
-nightly = []
-unstable = ["lints"]
-lints = ["clippy", "nightly"]
-travis = ["nightly", "lints"]
+lints = []
+travis = ["lints"]
 
 [profile.release]
 lto = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,19 +71,18 @@
 //! ## License
 //!
 //! `cargo-outdated` is released under the terms of the MIT license. See the LICENSE-MIT file for the details.
-#![cfg_attr(feature = "nightly", feature(plugin))]
-#![cfg_attr(feature = "lints", plugin(clippy))]
+
 #![cfg_attr(feature = "lints", allow(explicit_iter_loop))]
 #![cfg_attr(feature = "lints", allow(should_implement_trait))]
 #![cfg_attr(feature = "lints", deny(warnings))]
-#![cfg_attr(not(any(feature = "unstable", feature = "nightly")), deny(unstable_features))]
 #![deny(missing_docs,
         missing_debug_implementations,
         missing_copy_implementations,
         trivial_casts, trivial_numeric_casts,
         unsafe_code,
         unused_import_braces,
-        unused_qualifications)]
+        unused_qualifications,
+        unstable_features)]
 
 #[macro_use]
 extern crate clap;


### PR DESCRIPTION
Clippy can now be easily run using `cargo clippy`, so there's no point
in using `#![plugin]`.

Removes the `clippy`, `nightly` and `unstable` features.

I've kept the `lints` feature, which is still useful for use with
clippy.
