### PR TITLE
Fix recursion through indirect dependencies

### DIFF
--- a/src/deps/raw_dep.rs
+++ b/src/deps/raw_dep.rs
@@ -9,6 +9,15 @@ pub struct RawDep {
     pub parent: Option<String>,
 }
 
+impl RawDep {
+    pub fn label(&self) -> String {
+        match self.parent {
+            Some(ref parent) => format!("{}->{}", parent, self.name),
+            None => self.name.clone()
+        }
+    }
+}
+
 impl FromStr for RawDep {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -150,7 +150,7 @@ impl Lockfile {
                 if semver_dep.ver != d.ver {
                     res.insert(d_name.to_owned(),
                                Dep {
-                                   name: d_name.to_owned(),
+                                   name: d.label(),
                                    source: d.source.clone(),
                                    project_ver: d.ver.clone(),
                                    semver_ver: Some(semver_dep.ver.clone()),
@@ -219,7 +219,7 @@ impl Lockfile {
                     if !exists {
                         res.insert(d_name.to_owned(),
                                    Dep {
-                                       name: d_name.to_owned(),
+                                       name: d.label(),
                                        source: d.source.clone(),
                                        project_ver: d.ver.clone(),
                                        semver_ver: None,
@@ -310,14 +310,7 @@ impl Lockfile {
                             }
                         }
                         for child in next_level.into_iter() {
-                            self.deps
-                                .insert(format!("{}->{}",
-                                                child.parent
-                                                    .as_ref()
-                                                    .expect("child dependency has no parent node")
-                                                    .clone(),
-                                                child.name.clone()),
-                                        child);
+                            self.deps.insert(child.name.clone(), child);
                         }
                     }
                     depth = if depth > 0 { depth - 1 } else { break; };

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,10 +180,10 @@ fn execute(m: &ArgMatches) -> CliResult<i32> {
             let mut tw = TabWriter::new(vec![]);
             write!(&mut tw, "\tName\tProject Ver\tSemVer Compat\tLatest Ver\n")
                 .unwrap_or_else(|e| panic!("write! error: {}", e));
-            for (d_name, d) in res.iter() {
+            for d in res.values() {
                 write!(&mut tw,
                        "\t{}\t   {}\t   {}\t  {}\n",
-                       d_name,
+                       d.name,
                        d.project_ver,
                        d.semver_ver
                         .as_ref()


### PR DESCRIPTION
This fixes a bug where some indirect dependencies were not processed, because they were added to the `deps` map with a name like `foo->bar`, so they weren't found when a later pass checked for just `bar`.