### PR TITLE
style(elaborate_workspace): Underline headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Once installed (see below) running `cargo outdated` in a project directory looks
 ```
 $ cargo outdated
 Name             Project  Compat  Latest   Kind         Platform
+----             -------  ------  ------   ----         --------
 clap             2.20.0   2.20.5  2.26.0   Normal       ---
 clap->bitflags   0.7.0    ---     0.9.1    Normal       ---
 clap->libc       0.2.18   0.2.29  Removed  Normal       ---

--- a/src/cargo_ops/elaborate_workspace.rs
+++ b/src/cargo_ops/elaborate_workspace.rs
@@ -253,6 +253,7 @@ impl<'ela> ElaborateWorkspace<'ela> {
         } else {
             let mut tw = TabWriter::new(vec![]);
             write!(&mut tw, "Name\tProject\tCompat\tLatest\tKind\tPlatform\n")?;
+            write!(&mut tw, "----\t-------\t------\t------\t----\t--------\n")?;
             for line in lines {
                 write!(&mut tw, "{}", line)?;
             }


### PR DESCRIPTION
This makes the output look a little bit nicer:

```
$ cargo outdated
Name                    Project  Compat  Latest  Kind    Platform
parking_lot_core->libc  0.2.30   0.2.31  0.2.31  Normal  cfg(unix)
rand->libc              0.2.30   0.2.31  0.2.31  Normal  ---
rbpf->libc              0.2.30   0.2.31  0.2.31  Normal  ---
time->libc              0.2.30   0.2.31  0.2.31  Normal  ---
$ cargo outdated
Name                    Project  Compat  Latest  Kind    Platform
----                    -------  ------  ------  ----    --------
parking_lot_core->libc  0.2.30   0.2.31  0.2.31  Normal  cfg(unix)
rand->libc              0.2.30   0.2.31  0.2.31  Normal  ---
rbpf->libc              0.2.30   0.2.31  0.2.31  Normal  ---
time->libc              0.2.30   0.2.31  0.2.31  Normal  ---
```
