### PR TITLE
imp: provide `--workspace` flag to enforce workspace mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ FLAGS:
     -R, --root-deps-only         Only check root dependencies (Equivalent to --depth=1)
     -V, --version                Prints version information
     -v, --verbose                Use verbose output
+    -w, --workspace              Check updates for all workspace members
+                                 rather than only the root package
 
 OPTIONS:
         --color <color>           Coloring: auto, always, never [default: auto]


### PR DESCRIPTION
Fixes #81 

And since the root package is actually a workspace member itself, running `cargo outdated` with or without `-w` gives the same output if cargo workspace feature is not enabled.

Finger crossed that there are no side effects.