### PR TITLE
imp: queries crates.io api for new versions and feature changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,13 @@ USAGE:
     cargo outdated [FLAGS] [OPTIONS]
 
 FLAGS:
+    -a, --aggressive             Ignores channels for latest updates
     -h, --help                   Prints help information
+    -q, --quiet                  Suppresses warnings
     -R, --root-deps-only         Only check root dependencies (Equivalent to --depth=1)
     -V, --version                Prints version information
     -v, --verbose                Use verbose output
-    -w, --workspace              Check updates for all workspace members
+    -w, --workspace              Checks updates for all workspace members
                                  rather than only the root package
 
 OPTIONS:

--- a/src/cargo_ops/mod.rs
+++ b/src/cargo_ops/mod.rs
@@ -11,7 +11,8 @@ pub use self::elaborate_workspace::ElaborateWorkspace;
 /// A continent struct for quick parsing and manipulating manifest
 #[derive(Debug, Serialize, Deserialize)]
 struct Manifest {
-    pub package: Value,
+    #[serde(serialize_with = "::toml::ser::tables_last")]
+    pub package: Table,
     #[serde(skip_serializing_if = "Option::is_none", serialize_with = "opt_tables_last")]
     pub dependencies: Option<Table>,
     #[serde(rename = "dev-dependencies", skip_serializing_if = "Option::is_none",
@@ -27,6 +28,15 @@ struct Manifest {
     #[serde(skip_serializing_if = "Option::is_none", serialize_with = "opt_tables_last")]
     pub target: Option<Table>,
     pub features: Option<Value>,
+}
+
+impl Manifest {
+    pub fn name(&self) -> String {
+        match self.package["name"] {
+            Value::String(ref name) => name.clone(),
+            _ => unreachable!(),
+        }
+    }
 }
 
 pub fn opt_tables_last<S>(data: &Option<Table>, serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
Fixes #84
Fixes #75
Rebase before merge

- [x] Calls [`Registry::query()`](https://docs.rs/cargo/0.22.0/cargo/core/registry/trait.Registry.html#tymethod.query) for latest package info
- [x] Uses [`Summary::version()`](https://docs.rs/cargo/0.22.0/cargo/core/summary/struct.Summary.html#method.version) instead of `"*"`
- [x] Removes features that do not exist in newer versions from temporary manifest files and show warnings to users
- [x] Error handling of the `TempProject::manipulate_dependencies()` part
- [x] Adds a new flag to ignore channels of latest versions
- [x] Test whether it causes any regressions