### PR TITLE
fix: rewrite dependency tree comparison algorithm

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -281,7 +281,7 @@ pub fn execute(options: Options, config: &Config) -> CargoResult<i32> {
     if options.flag_verbose == 0 {
         config.shell().set_verbosity(Verbosity::Quiet);
     }
-    let mut ela_curr = ElaborateWorkspace::from_workspace(&curr_workspace, &options)?;
+    let ela_curr = ElaborateWorkspace::from_workspace(&curr_workspace, &options)?;
     if options.flag_verbose > 0 {
         config.shell().set_verbosity(Verbosity::Verbose);
     } else {
@@ -338,9 +338,9 @@ pub fn execute(options: Options, config: &Config) -> CargoResult<i32> {
     } else {
         verbose!(config, "Resolving...", "package status");
         let root = ela_curr.determine_root(&options)?;
-        ela_curr.resolve_status(&ela_compat, &ela_latest, &options, config, &root)?;
+        ela_curr.resolve_status(&ela_compat, &ela_latest, &options, config, root)?;
         verbose!(config, "Printing...", "list format");
-        let count = ela_curr.print_list(&options, &root, false)?;
+        let count = ela_curr.print_list(&options, root, false)?;
         Ok(count)
     }
 }


### PR DESCRIPTION
Fixes #105 

There was a bug in the old algorithm: `(grand, parent, self)` should not be used as the identifier of a package in the dependency tree.

The dependency tree comparison part has been rewritten to fix it and adopt BFS instead of DFS. No idea why I wrote a verbose DFS...