### PR TITLE
Emit an error, when package key is not a string.

### DIFF
--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -398,8 +398,7 @@ impl<'tmp> TempProject<'tmp> {
                 Value::Table(ref t) => {
                     let name = match t.get("package") {
                         Some(&Value::String(ref s)) => s,
-                        // TODO: Probably this should emit an error?
-                        Some(_) => &dep_key,
+                        Some(_) => panic!("'package' of dependency {} is not a string", dep_key),
                         None => &dep_key,
                     };
 


### PR DESCRIPTION
Minor change, that didn't make it into the last PR (using panic for this is not so nice but cargo fails before this is reached anyway, this commit is just to remove the TODO from my last commit):
https://github.com/kbknapp/cargo-outdated/pull/161#discussion_r253272795