### PR TITLE
Makes cargo-outdated more resilient to edge cases in finding dependencies

### DIFF
--- a/src/cargo_ops/elaborate_workspace.rs
+++ b/src/cargo_ops/elaborate_workspace.rs
@@ -126,6 +126,11 @@ impl<'ela> ElaborateWorkspace<'ela> {
                 return Ok(direct_dep.clone());
             }
         }
+        for (pkg_id, pkg) in &self.pkgs {
+            if pkg.name().as_str() == dependency_name {
+                return Ok(pkg_id.clone());
+            }
+        }
         Err(format_err!(
             "Direct dependency {} not found for package {}",
             dependency_name,

--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -389,7 +389,7 @@ impl<'tmp> TempProject<'tmp> {
                             Result::Ok(val) => dependencies
                                 .insert(name.clone(), Value::String(val.version().to_string())),
                             Result::Err(_err) => {
-                                err_msg(format!(
+                                eprintln!(format!(
                                     "Updates to dependency {} could not be found",
                                     name.clone()
                                 ));
@@ -438,7 +438,7 @@ impl<'tmp> TempProject<'tmp> {
                     match r_summary {
                         Result::Ok(val) => summary = val,
                         Result::Err(_) => {
-                            err_msg(format!("Update for {} could not be found!", name.clone()));
+                            eprintln(format!("Update for {} could not be found!", name.clone()));
                             return Ok(());
                         }
                     };

--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -389,10 +389,10 @@ impl<'tmp> TempProject<'tmp> {
                             Result::Ok(val) => dependencies
                                 .insert(name.clone(), Value::String(val.version().to_string())),
                             Result::Err(_err) => {
-                                eprintln!(format!(
+                                eprintln!(
                                     "Updates to dependency {} could not be found",
                                     name.clone()
-                                ));
+                                );
                                 None
                             }
                         };
@@ -438,7 +438,7 @@ impl<'tmp> TempProject<'tmp> {
                     match r_summary {
                         Result::Ok(val) => summary = val,
                         Result::Err(_) => {
-                            eprintln(format!("Update for {} could not be found!", name.clone()));
+                            eprintln!("Update for {} could not be found!", name.clone());
                             return Ok(());
                         }
                     };


### PR DESCRIPTION
Some edge cases (e.g. vendored content) make cargo fail.

It's still useful for cargo-outdated to return a result in this case. This catches failures of expansion and makes them warnings rather than failure cases.

This makes cargo-outdated's output partial, but still useful