### PR TITLE
Bump cargo to 0.38

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ travis-ci = {repository = "kbknapp/cargo-outdated"}
 name = "cargo-outdated"
 
 [dependencies]
-cargo = "0.37.0"
+cargo = "0.38.0"
 docopt = "1.0.0"
 env_logger = "0.6.0"
 failure = "0.1.1"


### PR DESCRIPTION
Fixes https://github.com/kbknapp/cargo-outdated/issues/173