### PR TITLE
Changed the version parsing in temp_project.rs:valid_latest_version()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-outdated"
-version = "0.9.0"
+version = "0.9.1"
 authors = [
     "Kevin K. <kbknapp@gmail.com>",
     "Frederick Z. <frederick888@tsundere.moe>",

--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -625,14 +625,12 @@ fn valid_latest_version(requirement: &str, version: &Version) -> bool {
         (false, false) | (true, false) => true,
         // both are unstable, must be in the same channel
         (true, true) => {
-            let requirement_channel = {
-                let pre = requirement.split(&['-', '+'][..]).nth(1).unwrap();
-                pre.trim_matches(|c| !char::is_alphabetic(c))
-            };
+            let requirement_version = Version::parse(requirement).expect("Error could not parse requirement into a semantic version"); 
+            let requirement_channel = requirement_version.pre[0].to_string();
             match (requirement_channel.is_empty(), &version.pre[0]) {
                 (true, &Identifier::Numeric(_)) => true,
-                (false, &Identifier::AlphaNumeric(ref pre)) => {
-                    requirement_channel == pre.trim_matches(char::is_numeric)
+                (false, &Identifier::AlphaNumeric(_)) => {
+                    Identifier::AlphaNumeric(requirement_channel) == version.pre[0]
                 }
                 _ => false,
             }


### PR DESCRIPTION
This using the already included `semver` crate to parse the channels (`alpha`, `beta`, etc.) rather than string splits and slices. 

Resolves the panic in #168 because the parsing wasn't fully pulling the "alpha" to compare it to the latest release (which was parsed with `semver`). 

This PR **doesn't** solve the fact that it is **not** comparing the latest pre-release channel and will report that `0.2.0-alpha.2` is up-to-date with `0.2.0-alpha.2a` for a specific example. 

I will put in a seperate PR for that fix which I need to start looking into shortly.....