### PR TITLE
[WIP] Adding Network Configuration Options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,9 +142,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-outdated"
-
 version = "0.9.2"
-
 dependencies = [
  "cargo 0.40.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/cargo_ops/mod.rs
+++ b/src/cargo_ops/mod.rs
@@ -43,6 +43,11 @@ struct Manifest {
     )]
     pub target: Option<Table>,
     pub features: Option<Value>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "opt_tables_last"
+    )]
+    pub net: Option<Table>,
 }
 
 impl Manifest {

--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -77,9 +77,11 @@ impl<'tmp> TempProject<'tmp> {
             // Check for network configurations in the net module that will affect how
             // We get the packages updated
             match om.net {
-                Some(ref x) => {
-                    if x.contains_key("git-fetch-with-cli") {
-                        std::env::set_var("CARGO_NET_GIT_FETCH_WITH_CLI", "true");
+                Some(ref network_options) => {
+                    if network_options.contains_key("git-fetch-with-cli") {
+                        if network_options["git-fetch-with-cli"] == toml::value::Value::Boolean(true) {
+                            std::env::set_var("CARGO_NET_GIT_FETCH_WITH_CLI", "true");
+                        }
                     }
 
                     //We should check for more options that need set proxy? any others? 
@@ -115,12 +117,6 @@ impl<'tmp> TempProject<'tmp> {
 
         let relative_manifest = String::from(&orig_manifest[workspace_root_str.len() + 1..]);
         let config = Self::generate_config(temp_dir.path(), &relative_manifest, options)?;
-
-        //checking to see if we have net git_fetch_with_cli set
-        //if so, update the environment variable so we can properly fetch the package
-       // if om.net.is_some("git-fetch-with-cli") {
-       //     config.env.insert("CARGO_NET_GIT_FETCH_WITH_CLI".to_string(), "true".to_string());
-       // }
 
         Ok(TempProject {
             workspace: Rc::new(RefCell::new(None)),


### PR DESCRIPTION
Resolves #183 by adding the `[net]` Manifest section and adding the environmental variable for `git-fetch-with-cli` option. 

We should discuss adding other options to the build environment when running updates like possibly `http(s) proxy`, or anything else that might cause fetching a crate to fail. 