### PR TITLE
Fixing .cargo/config options

### DIFF
--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -100,6 +100,12 @@ impl<'tmp> TempProject<'tmp> {
             }
         }
 
+        //.cargo/config 
+        if workspace_root.join(".cargo/config").is_file() {
+            fs::create_dir_all( temp_dir.path().join(".cargo"))?;
+            fs::copy(&workspace_root.join(".cargo/config"), temp_dir.path().join(".cargo/config"))?;
+        }
+
         let relative_manifest = String::from(&orig_manifest[workspace_root_str.len() + 1..]);
         let config = Self::generate_config(temp_dir.path(), &relative_manifest, options)?;
         


### PR DESCRIPTION
Resolves #183 by copying in the `.cargo/config` file to the temporary working directory if it exists in the root. 