### PR TITLE
[WIP] Remove the $CARGO_HOME environment variable if it exists, as we do not use it …

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -106,10 +106,7 @@ fn main() {
     // Check if $CARGO_HOME is set before capturing the config environment 
     // if it is, remove it, we build the project in a temporary directory
     if std::env::var_os("CARGO_HOME").is_some() {
-        Ok(_) => {
-            std::env::remove_var("CARGO_HOME");
-        },
-        Err(_) => {},
+        std::env::remove_var("CARGO_HOME");
     }
 
     let mut config = match Config::default() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,15 @@ fn main() {
         options
     };
 
+    // Check if $CARGO_HOME is set before capturing the config environment 
+    // if it is, remove it, we build the project in a temporary directory
+    match std::env::var("CARGO_HOME") {
+        Ok(_) => {
+            std::env::remove_var("CARGO_HOME");
+        },
+        Err(_) => {},
+    }
+
     let mut config = match Config::default() {
         Ok(cfg) => cfg,
         Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ fn main() {
 
     // Check if $CARGO_HOME is set before capturing the config environment 
     // if it is, remove it, we build the project in a temporary directory
-    match std::env::var("CARGO_HOME") {
+    if std::env::var_os("CARGO_HOME").is_some() {
         Ok(_) => {
             std::env::remove_var("CARGO_HOME");
         },


### PR DESCRIPTION
…for dependency resolution and it will point cargo to the wrong location to check the dependency cache

Resolves #193  

No sure it's the most elegant solution, thoughts? 