### PR TITLE
Updated main function to check for custom http envirnoment and update…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,9 +8,9 @@ checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f56c476256dc249def911d6f7580b5fc7e875895b5d7ee88f5d602208035744"
+checksum = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"
 dependencies = [
  "memchr",
 ]
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe8a65814ca90dfc9705af76bb6ba3c6e2534489a72270e797e603783bb4990b"
+checksum = "502ae1441a0a5adb8fbd38a5955a6416b9493e92b465de5e4a9bde6a539c2c48"
 dependencies = [
  "memchr",
 ]
@@ -171,12 +171,13 @@ dependencies = [
 
 [[package]]
 name = "cargo-outdated"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "cargo",
  "docopt",
  "env_logger",
  "failure",
+ "git2-curl",
  "semver",
  "serde",
  "serde_derive",
@@ -705,9 +706,9 @@ checksum = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f3f74f726ae935c3f514300cc6773a0c9492abc5e972d42ba0c0ebb88757625"
+checksum = "aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5"
 dependencies = [
  "adler32",
 ]
@@ -743,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.27"
+version = "0.10.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e176a45fedd4c990e26580847a525e39e16ec32ac78957dbf62ded31b3abfd6f"
+checksum = "973293749822d7dd6370d6da1e523b0d1db19f06c459134c658b2a4261378b52"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -940,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
+checksum = "507a9e6e8ffe0a4e0ebb9a10293e62fdf7657c06f1b8bb07a8fcf697d2abf295"
 dependencies = [
  "lazy_static",
  "winapi",
@@ -995,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab8f15f15d6c41a154c1b128a22f2dfabe350ef53c40953d84e36155c91192b"
+checksum = "21b01d7f0288608a01dca632cf1df859df6fd6ffa885300fc275ce2ba6221953"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-outdated"
-version = "0.9.5"
+version = "0.9.6"
 authors = [
     "Kevin K. <kbknapp@gmail.com>",
     "Frederick Z. <frederick888@tsundere.moe>",
@@ -30,6 +30,7 @@ name = "cargo-outdated"
 cargo = "0.42"
 docopt = "1.0.0"
 env_logger = "0.7.0"
+git2-curl = "0.11"
 failure = "0.1.1"
 semver = "0.9.0"
 serde = {version="1.0.11", features = ["derive"]}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,11 @@ use crate::cargo_ops::{ElaborateWorkspace, TempProject};
 use cargo::core::maybe_allow_nightly_features;
 use cargo::core::shell::Verbosity;
 use cargo::core::Workspace;
+use cargo::ops::needs_custom_http_transport;
 use cargo::util::important_paths::find_root_manifest_for_wd;
 use cargo::util::{CargoResult, CliError, Config};
 use docopt::Docopt;
+use git2_curl;
 
 pub const USAGE: &str = "
 Displays information about project dependency versions
@@ -108,6 +110,27 @@ fn main() {
             cargo::exit_with_error(e.into(), &mut shell)
         }
     };
+
+    // Only use a custom transport if any HTTP options are specified,
+    // such as proxies or custom certificate authorities. The custom
+    // transport, however, is not as well battle-tested.
+    // See cargo-outdated issue #197 and 
+    // https://github.com/rust-lang/cargo/blob/master/src/bin/cargo/main.rs#L181 
+    // fn init_git_transports()
+    match needs_custom_http_transport(&config) {
+        Ok(true) => {
+            match cargo::ops::http_handle(&config) {
+                Ok(handle) => {
+                    unsafe {
+                        git2_curl::register(handle);
+                    }
+                },
+                Err(_) => {}
+            }
+        },
+        _ => {},
+    }
+
     let exit_code = options.flag_exit_code;
     let result = execute(options, &mut config);
     match result {


### PR DESCRIPTION
… the git2_curl handle like cargo does.

As per #197 (and #191) this will resolve any custom HTTP environment settings set by the user. This is also how `cargo` makes sure all requests are sent through the proxy (see issue conversation). Without this only the earlier requests are made with the proxy settings. 

I tested this both on and off proxies and did not hit any errors. 

I suggest merging #200, then this PR, and cutting a new release because proxies are pretty common around environments. :) 