### PR TITLE
fix help text of --manifest-path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Options:
                                 (Defaults to all dependencies when omitted)
         --exit-code NUM         The exit code to return on new versions found [default: 0]
         --features FEATURES     Space-separated list of features
-    -m, --manifest-path FILE    An absolute path to the Cargo.toml file to use
+    -m, --manifest-path FILE    Path to the Cargo.toml file to use
                                 (Defaults to Cargo.toml in project root)
     -p, --packages PKGS         Packages to inspect for updates
     -r, --root ROOT             Package to treat as the root package


### PR DESCRIPTION
In my previous PR that allows relative manifest path, I forgot changing the output example of `--help` in README.md.