### PR TITLE
Enables reading from the  `$CARGO_HOME` directory and properly fixes …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-outdated"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "cargo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-outdated"
-version = "0.9.8"
+version = "0.9.9"
 authors = [
     "Kevin K. <kbknapp@gmail.com>",
     "Frederick Z. <frederick888@tsundere.moe>",

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ term_size->libc  0.2.18   0.2.29  0.2.29   Normal       cfg(not(target_os = "win
 The latest version of `cargo-outdated` can be installed or updated with `cargo install`:
 
 ```sh
-cargo install --force cargo-outdated --locked
+cargo install cargo-outdated
 ```
 or
 
 ```sh
-cargo install --force --git https://github.com/kbknapp/cargo-outdated --locked
+cargo install --git https://github.com/kbknapp/cargo-outdated
 ```
 
 ## Compiling

--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -154,6 +154,14 @@ impl<'tmp> TempProject<'tmp> {
         })?;
         let mut cwd = Path::new(root).join(relative_manifest);
         cwd.pop();
+        
+        // Check if $CARGO_HOME is set before capturing the config environment 
+        // if it is, set it in the configure options 
+        let cargo_home_path = match std::env::var_os("CARGO_HOME") {
+            Some(path) => Some(std::path::PathBuf::from(path)),
+            None => None
+        };
+
         let mut config = Config::new(shell, cwd, homedir);
         config.configure(
             0,
@@ -166,7 +174,7 @@ impl<'tmp> TempProject<'tmp> {
             options.frozen(),
             options.locked(),
             false,
-            &None,
+            &cargo_home_path,
             &[],
             &[],
         )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,11 +103,7 @@ fn main() {
         options
     };
 
-    // Check if $CARGO_HOME is set before capturing the config environment 
-    // if it is, remove it, we build the project in a temporary directory
-    if std::env::var_os("CARGO_HOME").is_some() {
-        std::env::remove_var("CARGO_HOME");
-    }
+
 
     let mut config = match Config::default() {
         Ok(cfg) => cfg,
@@ -156,6 +152,13 @@ fn main() {
 }
 
 pub fn execute(options: Options, config: &mut Config) -> CargoResult<i32> {
+    // Check if $CARGO_HOME is set before capturing the config environment 
+    // if it is, set it in the configure options 
+    let cargo_home_path = match std::env::var_os("CARGO_HOME") {
+        Some(path) => Some(std::path::PathBuf::from(path)),
+        None => None
+    };
+
     config.configure(
         options.flag_verbose,
         None,
@@ -163,7 +166,7 @@ pub fn execute(options: Options, config: &mut Config) -> CargoResult<i32> {
         options.frozen(),
         options.locked(),
         false,
-        &None,
+        &cargo_home_path,
         &[],
         &[],
     )?;


### PR DESCRIPTION
…#211. 

This allows `cargo outdated` to respect the $CARGO_HOME variable. 