### PR TITLE
Add `$CARGO_HOME` to `cargo` build path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-outdated"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "cargo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-outdated"
-version = "0.9.8"
+version = "0.9.9"
 authors = [
     "Kevin K. <kbknapp@gmail.com>",
     "Frederick Z. <frederick888@tsundere.moe>",

--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -154,6 +154,14 @@ impl<'tmp> TempProject<'tmp> {
         })?;
         let mut cwd = Path::new(root).join(relative_manifest);
         cwd.pop();
+        
+        // Check if $CARGO_HOME is set before capturing the config environment 
+        // if it is, set it in the configure options 
+        let cargo_home_path = match std::env::var_os("CARGO_HOME") {
+            Some(path) => Some(std::path::PathBuf::from(path)),
+            None => None
+        };
+
         let mut config = Config::new(shell, cwd, homedir);
         config.configure(
             0,
@@ -166,7 +174,7 @@ impl<'tmp> TempProject<'tmp> {
             options.frozen(),
             options.locked(),
             false,
-            &None,
+            &cargo_home_path,
             &[],
             &[],
         )?;

--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -654,9 +654,16 @@ fn manifest_paths(elab: &ElaborateWorkspace<'_>) -> CargoResult<Vec<PathBuf>> {
         visited.insert(pkg_id);
         let pkg = &elab.pkgs[&pkg_id];
         let pkg_path = pkg.root().to_string_lossy();
-        if pkg_path.starts_with(workspace_path) {
-            manifest_paths.push(pkg.manifest_path().to_owned());
-        }
+        let cargo_home_path = match std::env::var_os("CARGO_HOME") {
+             Some(path) => path.into_string().expect("Error getting string from OsString"),
+             None => "".to_string(),
+         };
+
+         if pkg_path.starts_with(workspace_path) {
+             if !pkg_path.starts_with(&cargo_home_path){
+                 manifest_paths.push(pkg.manifest_path().to_owned());
+             }
+         }        
 
         for &dep in elab.pkg_deps[&pkg_id].keys() {
             manifest_paths_recursive(dep, elab, workspace_path, visited, manifest_paths)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,11 +103,7 @@ fn main() {
         options
     };
 
-    // Check if $CARGO_HOME is set before capturing the config environment 
-    // if it is, remove it, we build the project in a temporary directory
-    if std::env::var_os("CARGO_HOME").is_some() {
-        std::env::remove_var("CARGO_HOME");
-    }
+
 
     let mut config = match Config::default() {
         Ok(cfg) => cfg,
@@ -156,6 +152,13 @@ fn main() {
 }
 
 pub fn execute(options: Options, config: &mut Config) -> CargoResult<i32> {
+    // Check if $CARGO_HOME is set before capturing the config environment 
+    // if it is, set it in the configure options 
+    let cargo_home_path = match std::env::var_os("CARGO_HOME") {
+        Some(path) => Some(std::path::PathBuf::from(path)),
+        None => None
+    };
+
     config.configure(
         options.flag_verbose,
         None,
@@ -163,7 +166,7 @@ pub fn execute(options: Options, config: &mut Config) -> CargoResult<i32> {
         options.frozen(),
         options.locked(),
         false,
-        &None,
+        &cargo_home_path,
         &[],
         &[],
     )?;


### PR DESCRIPTION
This PR enables `$CARGO_HOME` when building the temp projects with `cargo-outdated`. This alleviates the need for re-downloading dependencies each time `cargo-outdated` is ran. 

Tested on MacOS, Ubuntu locally. Partially(?) resolves #211 