### PR TITLE
Option for ignoring certain outdated dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Options:
     -h, --help                  Prints help information
         --format FORMAT         Output formatting [default: list]
                                 [values: list, json]
+    -i, --ignore DEPENDENCIES   Space separated list of dependencies to ignore
     -q, --quiet                 Suppresses warnings
     -R, --root-deps-only        Only check root dependencies (Equivalent to --depth=1)
     -V, --version               Prints version information

--- a/src/cargo_ops/elaborate_workspace.rs
+++ b/src/cargo_ops/elaborate_workspace.rs
@@ -237,12 +237,18 @@ impl<'ela> ElaborateWorkspace<'ela> {
         queue.push_back(vec![root]);
         while let Some(path) = queue.pop_front() {
             let pkg = path.last().unwrap();
+            let name = pkg.name().to_string();
+
+            if options.flag_ignore.contains(&name) {
+                continue;
+            }
+
             let depth = path.len() as i32 - 1;
             // generate lines
             let status = &self.pkg_status.borrow_mut()[&path];
             if (status.compat.is_changed() || status.latest.is_changed())
                 && (options.flag_packages.is_empty()
-                    || options.flag_packages.contains(&pkg.name().to_string()))
+                    || options.flag_packages.contains(&name))
             {
                 // name version compatible latest kind platform
                 let parent = path.get(path.len() - 2);
@@ -251,9 +257,9 @@ impl<'ela> ElaborateWorkspace<'ela> {
                     let label = if self.workspace_mode
                         || parent == &self.workspace.current()?.package_id()
                     {
-                        pkg.name().to_string()
+                        name
                     } else {
-                        format!("{}->{}", self.pkgs[parent].name(), pkg.name())
+                        format!("{}->{}", self.pkgs[parent].name(), name)
                     };
                     let line = format!(
                         "{}\t{}\t{}\t{}\t{:?}\t{}\n",
@@ -271,7 +277,7 @@ impl<'ela> ElaborateWorkspace<'ela> {
                 } else {
                     let line = format!(
                         "{}\t{}\t{}\t{}\t---\t---\n",
-                        pkg.name(),
+                        name,
                         pkg.version(),
                         status.compat.to_string(),
                         status.latest.to_string()
@@ -335,12 +341,18 @@ impl<'ela> ElaborateWorkspace<'ela> {
 
         while let Some(path) = queue.pop_front() {
             let pkg = path.last().unwrap();
+            let name = pkg.name().to_string();
+
+            if options.flag_ignore.contains(&name) {
+                continue;
+            }
+
             let depth = path.len() as i32 - 1;
             // generate lines
             let status = &self.pkg_status.borrow_mut()[&path];
             if (status.compat.is_changed() || status.latest.is_changed())
                 && (options.flag_packages.is_empty()
-                    || options.flag_packages.contains(&pkg.name().to_string()))
+                    || options.flag_packages.contains(&name))
             {
                 // name version compatible latest kind platform
                 let parent = path.get(path.len() - 2);
@@ -352,9 +364,9 @@ impl<'ela> ElaborateWorkspace<'ela> {
                     let label = if self.workspace_mode
                         || parent == &self.workspace.current()?.package_id()
                     {
-                        pkg.name().to_string()
+                        name
                     } else {
-                        format!("{}->{}", self.pkgs[parent].name(), pkg.name())
+                        format!("{}->{}", self.pkgs[parent].name(), name)
                     };
 
                     let dependency_type = match dependency.kind() {
@@ -373,7 +385,7 @@ impl<'ela> ElaborateWorkspace<'ela> {
                     };
                 } else {
                     line = Metadata {
-                        name: pkg.name().to_string(),
+                        name,
                         project: pkg.version().to_string(),
                         compat: status.compat.to_string(),
                         latest: status.latest.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ Options:
     -h, --help                  Prints help information
         --format FORMAT         Output formatting [default: list]
                                 [values: list, json]
+    -i, --ignore DEPENDENCIES   Space separated list of dependencies to ignore
     -q, --quiet                 Suppresses warnings
     -R, --root-deps-only        Only check root dependencies (Equivalent to --depth=1)
     -V, --version               Prints version information
@@ -52,6 +53,7 @@ pub struct Options {
     flag_format: Option<String>,
     flag_color: Option<String>,
     flag_features: Vec<String>,
+    flag_ignore: Vec<String>,
     flag_manifest_path: Option<String>,
     flag_quiet: bool,
     flag_verbose: u32,
@@ -96,6 +98,7 @@ fn main() {
                 .collect()
         }
         options.flag_features = flat_split(&options.flag_features);
+        options.flag_ignore = flat_split(&options.flag_ignore);
         options.flag_packages = flat_split(&options.flag_packages);
         if options.flag_root_deps_only {
             options.flag_depth = Some(1);


### PR DESCRIPTION
This is particularly useful when used together with `--exit-code 1`.

Given a situation like this:

```
$ cargo outdated
Name             Project  Compat  Latest   Kind         Platform
----             -------  ------  ------   ----         --------
clap             2.20.0   2.20.5  2.26.0   Normal       ---
clap->bitflags   0.7.0    ---     0.9.1    Normal       ---
clap->libc       0.2.18   0.2.29  Removed  Normal       ---
clap->term_size  0.2.1    0.2.3   0.3.0    Normal       ---
clap->vec_map    0.6.0    ---     0.8.0    Normal       ---
num_cpus         1.6.0    ---     1.6.2    Development  ---
num_cpus->libc   0.2.18   0.2.29  0.2.29   Normal       ---
pkg-config       0.3.8    0.3.9   0.3.9    Build        ---
term             0.4.5    ---     0.4.6    Normal       ---
term_size->libc  0.2.18   0.2.29  0.2.29   Normal       cfg(not(target_os = "windows"))
```

… ignoring `cargo` results in this:

```
$ cargo outdated --ignore clap
Name             Project  Compat  Latest   Kind         Platform
----             -------  ------  ------   ----         --------
num_cpus         1.6.0    ---     1.6.2    Development  ---
num_cpus->libc   0.2.18   0.2.29  0.2.29   Normal       ---
pkg-config       0.3.8    0.3.9   0.3.9    Build        ---
term             0.4.5    ---     0.4.6    Normal       ---
term_size->libc  0.2.18   0.2.29  0.2.29   Normal       cfg(not(target_os = "windows"))
```

Notice how the entire dependency subtree of `cargo` gets ignored along with the branch's root.

---

Fixes https://github.com/kbknapp/cargo-outdated/issues/226