### PR TITLE
Update Cargo and Fix Crash when Checking `semver` of crates 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,9 +79,9 @@ checksum = "716960a18f978640f25101b5cbf1c6f6b0d3192fab36a2d98ca96f0ecbe41010"
 
 [[package]]
 name = "cargo"
-version = "0.43.1"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91de5749ddcea3c283a042b67b77e2bdf68f28374cdcbfbe54e91368810d92e5"
+checksum = "0ff05aee1a7e1333a2b56eeec084153c1f5e0d37169cb4fa12b96df3f9965f56"
 dependencies = [
  "anyhow",
  "atty",
@@ -97,7 +97,6 @@ dependencies = [
  "env_logger",
  "filetime",
  "flate2",
- "fs2",
  "fwdansi",
  "git2",
  "git2-curl",
@@ -133,6 +132,7 @@ dependencies = [
  "termcolor",
  "toml",
  "unicode-width",
+ "unicode-xid",
  "url",
  "walkdir",
  "winapi",
@@ -345,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff6d4dab0aa0c8e6346d46052e93b13a16cf847b54ed357087c35011048cc7d"
+checksum = "affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695"
 dependencies = [
  "cfg-if",
  "libc",
@@ -390,16 +390,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "fwdansi"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.11.0"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77519ef7c5beee314d0804d4534f01e0f9e8d9acdee2b7a48627e590b27e0ec4"
+checksum = "11e4b2082980e751c4bf4273e9cbb4a02c655729c8ee8a79f66cad03c8f4d31e"
 dependencies = [
  "bitflags",
  "libc",
@@ -437,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "git2-curl"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2559abb1d87d27668d31bd868a000f0e2e0065d10e78961b62da95d7a7f1cc7"
+checksum = "502d532a2d06184beb3bc869d4d90236e60934e3382c921b203fa3c33e212bd7"
 dependencies = [
  "curl",
  "git2",
@@ -590,9 +580,9 @@ checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.10.0"
+version = "0.12.7+1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ec6bca50549d34a392611dde775123086acbd994e3fff64954777ce2dc2e51"
+checksum = "bcd07968649bcb7b9351ecfde53ca4d27673cccfdf57c84255ec18710f3153e0"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-outdated"
-version = "0.9.10"
+version = "0.9.11"
 authors = [
     "Kevin K. <kbknapp@gmail.com>",
     "Frederick Z. <frederick888@tsundere.moe>",
@@ -28,10 +28,10 @@ name = "cargo-outdated"
 
 [dependencies]
 anyhow = "1.0"
-cargo = "0.43.1"
+cargo = "0.45.1"
 docopt = "1.0.0"
 env_logger = "0.7.0"
-git2-curl = "0.12.0"
+git2-curl = "0.14.0"
 semver = "0.9.0"
 serde = {version="1.0.11", features = ["derive"]}
 serde_derive = "1.0.11"

--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -166,9 +166,9 @@ impl<'tmp> TempProject<'tmp> {
         config.configure(
             0,
             if options.flag_verbose > 0 {
-                None
+                false
             } else {
-                Some(true)
+                true
             },
             options.flag_color.as_deref(),
             options.frozen(),
@@ -374,10 +374,9 @@ impl<'tmp> TempProject<'tmp> {
                 }
             })
             .unwrap_or_else(|| {
-                panic!(
-                    "Cannot find matched versions of package {} from source {}",
-                    name, source_id
-                )
+                self.warn(format!("cannot compare {} crate version found in toml {} with crates.io latest {}", name, version_req.as_ref().unwrap(), query_result[0].version())).unwrap();
+                //this returns the latest version 
+                &query_result[0]
             });
         Ok(latest_result.clone())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ Options:
     -h, --help                  Prints help information
         --format FORMAT         Output formatting [default: list]
                                 [values: list, json]
+    -i, --ignore DEPENDENCIES   Space separated list of dependencies to ignore
     -q, --quiet                 Suppresses warnings
     -R, --root-deps-only        Only check root dependencies (Equivalent to --depth=1)
     -V, --version               Prints version information
@@ -52,6 +53,7 @@ pub struct Options {
     flag_format: Option<String>,
     flag_color: Option<String>,
     flag_features: Vec<String>,
+    flag_ignore: Vec<String>,
     flag_manifest_path: Option<String>,
     flag_quiet: bool,
     flag_verbose: u32,
@@ -96,6 +98,7 @@ fn main() {
                 .collect()
         }
         options.flag_features = flat_split(&options.flag_features);
+        options.flag_ignore = flat_split(&options.flag_ignore);
         options.flag_packages = flat_split(&options.flag_packages);
         if options.flag_root_deps_only {
             options.flag_depth = Some(1);
@@ -161,7 +164,7 @@ pub fn execute(options: Options, config: &mut Config) -> CargoResult<i32> {
 
     config.configure(
         options.flag_verbose,
-        None,
+        options.flag_quiet,
         options.flag_color.as_deref(),
         options.frozen(),
         options.locked(),


### PR DESCRIPTION
Updating Cargo to `0.45.1`, plus updated `temp_project.rs` to not panic on [`find_update()`](https://github.com/deg4uss3r/cargo-outdated/blob/main/src/cargo_ops/temp_project.rs#L377) when the version cannot be compared but rather emit a warning with the `Cargo.toml` file and `crates.io` versions differ. 

Closes #225 