### PR TITLE
Fix cargo config for 1.39+

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,9 +83,15 @@ fn main() {
     let options = {
         let mut options: Options = Docopt::new(USAGE)
             .and_then(|d| {
+                let mut args: Vec<_> = std::env::args().collect();
+                if args[1] != "outdated" {
+                    args.insert(1, "outdated".to_owned());
+                }
+
                 d.version(Some(
                     concat!(env!("CARGO_PKG_NAME"), " v", env!("CARGO_PKG_VERSION")).to_owned(),
                 ))
+                .argv(args)
                 .deserialize()
             })
             .unwrap_or_else(|e| e.exit());


### PR DESCRIPTION
Cargo as of 1.39 supports the `.toml` extension for `.cargo/config`, so this just follow the same logic as stated [here](https://doc.rust-lang.org/cargo/reference/config.html).

Also adds a workaround for the docopt behavior of requiring `outdated` be args[1] by just inserting it into the position if it's not there to allow just doing `cargo run` etc.