### PR TITLE
Add feature to build cargo with vendored openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ version = "1.0"
 
 [features]
 debug = ["termcolor"]
+vendored-openssl = ["cargo/vendored-openssl"]
 default = []
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ cp cargo-outdated ~/bin
 source ~/.bashrc
 ```
 
+### MacOS
+
+This library depends on OpenSSL. On MacOS a newer version of OpenSSL than is installed by default is needed. This can be installed with Homebrew via `brew install openssl` or openssl can be vendored in with `--features vendored-openssl`. [Learn more about building OpenSSL here](https://docs.rs/openssl/0.10.30/openssl/#building),
+
 ### Windows
 
 On Windows 7/8 you can add directory to the `PATH` variable by opening a command line as an administrator and running


### PR DESCRIPTION
Allows cargo-outdated to be built on MacOS without the need for a new version of OpenSSL (usually installed via homebrew)