### PR TITLE
Fix #241 JSON output formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-outdated"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "cargo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-outdated"
-version = "0.9.12"
+version = "0.9.13"
 authors = [
     "Kevin K. <kbknapp@gmail.com>",
     "Frederick Z. <frederick888@tsundere.moe>",


### PR DESCRIPTION
Moved from `serde_json::to_writer` to `serde_json::to_string` and `println!` (vice accessing by `io::stdout()`), also updated the data structure of dependencies from a `HashSet` to a `BTreeSet` with the ordering dependent on the crate name for more consistent output at the expense of a slight performance hit.

Resolves #241 