### PR TITLE
enabling Github CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,26 @@
+name: Rust
+"on":
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - "**"
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        rust_version: ['stable', 'beta', 'nightly']
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install Rust
+      if: startsWith(matrix.os, 'macOS')
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust_version }}
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,7 @@ name: Rust
   push:
     branches:
       - master
+      - main
   pull_request:
     branches:
       - "**"


### PR DESCRIPTION
Enables checks for [stable, beta, nightly] on [ubuntu, macOS, and Windows] using Github CI.