### PR TITLE
Carry Workspace Over

### DIFF
--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -27,6 +27,7 @@ pub struct TempProject<'tmp> {
     config: Config,
     relative_manifest: String,
     options: &'tmp Options,
+    is_workspace_project: bool,
 }
 
 impl<'tmp> TempProject<'tmp> {
@@ -39,6 +40,8 @@ impl<'tmp> TempProject<'tmp> {
         // e.g. /path/to/project
         let workspace_root = orig_workspace.workspace.root();
         let workspace_root_str = workspace_root.to_string_lossy();
+
+        println!("WORKSPACE MODE: {}", orig_workspace.workspace_mode);
 
         let temp_dir = Builder::new().prefix("cargo-outdated").tempdir()?;
         let manifest_paths = manifest_paths(orig_workspace)?;
@@ -103,8 +106,6 @@ impl<'tmp> TempProject<'tmp> {
                 dest.push("Cargo.lock");
                 fs::copy(lockfile, dest)?;
             }
-
-
         }
 
         // virtual root
@@ -134,6 +135,7 @@ impl<'tmp> TempProject<'tmp> {
             config,
             relative_manifest,
             options,
+            is_workspace_project: orig_workspace.workspace_mode,
         })
     }
 
@@ -189,7 +191,7 @@ impl<'tmp> TempProject<'tmp> {
             to_update: Vec::new(),
             config: &self.config,
             dry_run: false,
-            workspace: false,
+            workspace: self.is_workspace_project,
         };
         update_lockfile(self.workspace.borrow().as_ref().unwrap(), &update_opts)?;
         Ok(())

--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -40,9 +40,6 @@ impl<'tmp> TempProject<'tmp> {
         // e.g. /path/to/project
         let workspace_root = orig_workspace.workspace.root();
         let workspace_root_str = workspace_root.to_string_lossy();
-
-        println!("WORKSPACE MODE: {}", orig_workspace.workspace_mode);
-
         let temp_dir = Builder::new().prefix("cargo-outdated").tempdir()?;
         let manifest_paths = manifest_paths(orig_workspace)?;
         let mut tmp_manifest_paths = vec![];


### PR DESCRIPTION
Fixes the error where you cannot find a version for a specific crate by carrying workspace mode to the temp project

resolves #260 #230 #132