### PR TITLE
bump cargo 0.54 and run cargo +nightly fmt 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,19 +79,18 @@ checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
 
 [[package]]
 name = "cargo"
-version = "0.52.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668794d3757557250a8b7bf7d0920ca60910d9635e76d008caed037ec25c39b3"
+checksum = "6cbd976a733418564685769d03cca35bf228ddfc2c8a5e6771ca0f48ce80ae2e"
 dependencies = [
  "anyhow",
  "atty",
  "bytesize",
  "cargo-platform",
+ "cargo-util",
  "clap",
- "core-foundation",
  "crates-io",
  "crossbeam-utils",
- "crypto-hash",
  "curl",
  "curl-sys",
  "env_logger",
@@ -113,14 +112,13 @@ dependencies = [
  "libgit2-sys",
  "log",
  "memchr",
- "miow",
  "num_cpus",
  "opener",
  "openssl",
  "percent-encoding",
+ "rand",
  "rustc-workspace-hack",
  "rustfix",
- "same-file",
  "semver",
  "serde",
  "serde_ignored",
@@ -164,6 +162,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "cargo-util"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c5259672ff02c8c4d291fb52c9e6936d97dbfacea8d7011a0621aaaaab4c28"
+dependencies = [
+ "anyhow",
+ "core-foundation",
+ "crypto-hash",
+ "filetime",
+ "hex 0.4.3",
+ "jobserver",
+ "libc",
+ "log",
+ "miow",
+ "same-file",
+ "shell-escape",
+ "tempfile",
+ "walkdir",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ name = "cargo-outdated"
 
 [dependencies]
 anyhow = "1.0"
-cargo = "0.52.0"
+cargo = "0.54.0"
 docopt = "1.1.0"
 env_logger = "0.8.0"
 git2-curl = "0.14.0"

--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -6,10 +6,9 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 use cargo::core::{Dependency, PackageId, Summary, Verbosity, Workspace};
 use cargo::ops::{update_lockfile, UpdateOptions};
-use cargo::util::errors::CargoResultExt;
 use cargo::util::{CargoResult, Config};
 use semver::{Identifier, Version, VersionReq};
 use tempfile::{Builder, TempDir};
@@ -152,7 +151,7 @@ impl<'tmp> TempProject<'tmp> {
     ) -> CargoResult<Config> {
         let shell = ::cargo::core::Shell::new();
         let cwd = env::current_dir()
-            .chain_err(|| "Cargo couldn't get the current directory of the process")?;
+            .with_context(|| "Cargo couldn't get the current directory of the process")?;
 
         let homedir = ::cargo::util::homedir(&cwd).ok_or_else(|| {
             anyhow!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@ mod macros;
 mod cargo_ops;
 use crate::cargo_ops::{ElaborateWorkspace, TempProject};
 
-use cargo::core::maybe_allow_nightly_features;
 use cargo::core::shell::Verbosity;
 use cargo::core::Workspace;
 use cargo::ops::needs_custom_http_transport;
@@ -162,6 +161,9 @@ pub fn execute(options: Options, config: &mut Config) -> CargoResult<i32> {
         None => None
     };
 
+    // enabling nightly features
+    config.nightly_features_allowed = true;
+
     config.configure(
         options.flag_verbose,
         options.flag_quiet,
@@ -174,9 +176,6 @@ pub fn execute(options: Options, config: &mut Config) -> CargoResult<i32> {
         &[],
     )?;
     debug!(config, format!("options: {:?}", options));
-
-    // Needed to allow nightly features
-    maybe_allow_nightly_features();
 
     verbose!(config, "Parsing...", "current workspace");
     // the Cargo.toml that we are actually working on

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,8 +105,6 @@ fn main() {
         options
     };
 
-
-
     let mut config = match Config::default() {
         Ok(cfg) => cfg,
         Err(e) => {
@@ -118,21 +116,17 @@ fn main() {
     // Only use a custom transport if any HTTP options are specified,
     // such as proxies or custom certificate authorities. The custom
     // transport, however, is not as well battle-tested.
-    // See cargo-outdated issue #197 and 
-    // https://github.com/rust-lang/cargo/blob/master/src/bin/cargo/main.rs#L181 
+    // See cargo-outdated issue #197 and
+    // https://github.com/rust-lang/cargo/blob/master/src/bin/cargo/main.rs#L181
     // fn init_git_transports()
     match needs_custom_http_transport(&config) {
-        Ok(true) => {
-            match cargo::ops::http_handle(&config) {
-                Ok(handle) => {
-                    unsafe {
-                        git2_curl::register(handle);
-                    }
-                },
-                Err(_) => {}
-            }
+        Ok(true) => match cargo::ops::http_handle(&config) {
+            Ok(handle) => unsafe {
+                git2_curl::register(handle);
+            },
+            Err(_) => {}
         },
-        _ => {},
+        _ => {}
     }
 
     let exit_code = options.flag_exit_code;
@@ -154,11 +148,11 @@ fn main() {
 }
 
 pub fn execute(options: Options, config: &mut Config) -> CargoResult<i32> {
-    // Check if $CARGO_HOME is set before capturing the config environment 
-    // if it is, set it in the configure options 
+    // Check if $CARGO_HOME is set before capturing the config environment
+    // if it is, set it in the configure options
     let cargo_home_path = match std::env::var_os("CARGO_HOME") {
         Some(path) => Some(std::path::PathBuf::from(path)),
-        None => None
+        None => None,
     };
 
     // enabling nightly features


### PR DESCRIPTION
Tested features enabled with: 

```
[features]
tester = ["rand"]

[dependencies]
rand = { optional = true, version = "=0.8.1" }
```

produces: 

```
❯ cargo outdated
Name  Project  Compat  Latest  Kind    Platform
----  -------  ------  ------  ----    --------
rand  0.8.1    ---     0.8.4   Normal  ---

```

I need to bump the version and do a bit more testing before merging, I should have time to do this tomorrow. - 2021-06-20 

resolves #266 