### PR TITLE
Add the missing `cargo-features` entry in `Manifest`.

### DIFF
--- a/src/cargo_ops/mod.rs
+++ b/src/cargo_ops/mod.rs
@@ -11,10 +11,7 @@ pub use self::temp_project::TempProject;
 /// A continent struct for quick parsing and manipulating manifest
 #[derive(Debug, serde_derive::Serialize, serde_derive::Deserialize)]
 struct Manifest {
-    #[serde(
-        rename = "cargo-features",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "cargo-features", skip_serializing_if = "Option::is_none")]
     pub cargo_features: Option<Value>,
     #[serde(serialize_with = "::toml::ser::tables_last")]
     pub package: Table,

--- a/src/cargo_ops/mod.rs
+++ b/src/cargo_ops/mod.rs
@@ -11,6 +11,11 @@ pub use self::temp_project::TempProject;
 /// A continent struct for quick parsing and manipulating manifest
 #[derive(Debug, serde_derive::Serialize, serde_derive::Deserialize)]
 struct Manifest {
+    #[serde(
+        rename = "cargo-features",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cargo_features: Option<Value>,
     #[serde(serialize_with = "::toml::ser::tables_last")]
     pub package: Table,
     #[serde(


### PR DESCRIPTION
A project using 2021 edition has `cargo-features = ["edition2021"]` in its Cargo.toml but cargo-outdated ignores it when serialization/deserialization and fails to parse the compat workspace. By adding this cargo-outdated can work with projects with 2021 edition.