### PR TITLE
Support checking for offline updates against a local registry

### DIFF
--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -192,7 +192,7 @@ impl<'tmp> TempProject<'tmp> {
             options.flag_color.as_deref(),
             options.frozen(),
             options.locked(),
-            false,
+            options.flag_offline,
             &cargo_home_path,
             &[],
             &[],

--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -9,6 +9,7 @@ use std::rc::Rc;
 use anyhow::{anyhow, Context};
 use cargo::core::{Dependency, PackageId, Summary, Verbosity, Workspace};
 use cargo::ops::{update_lockfile, UpdateOptions};
+use cargo::sources::config::SourceConfigMap;
 use cargo::util::{CargoResult, Config};
 use semver::{Version, VersionReq};
 use tempfile::{Builder, TempDir};
@@ -370,7 +371,8 @@ impl<'tmp> TempProject<'tmp> {
         let package_id = workspace.find_direct_dependency(name, dependent_package_name)?;
         let version = package_id.version();
         let source_id = package_id.source_id().with_precise(None);
-        let mut source = source_id.load(&self.config, &HashSet::new())?;
+        let source_config = SourceConfigMap::new(workspace.workspace.config())?;
+        let mut source = source_config.load(source_id, &HashSet::new())?;
         if !source_id.is_default_registry() {
             let _lock = self.config.acquire_package_cache_lock()?;
             source.update()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ Options:
                                 (Defaults to Cargo.toml in project root)
     -p, --packages PKGS         Packages to inspect for updates
     -r, --root ROOT             Package to treat as the root package
+    -o, --offline               Run without accessing the network (useful for testing w/ local registries)
 ";
 
 /// Options from CLI arguments
@@ -70,6 +71,7 @@ pub struct Options {
     flag_root_deps_only: bool,
     flag_workspace: bool,
     flag_aggressive: bool,
+    flag_offline: bool,
 }
 
 impl Options {
@@ -168,7 +170,7 @@ pub fn execute(options: Options, config: &mut Config) -> CargoResult<i32> {
         options.flag_color.as_deref(),
         options.frozen(),
         options.locked(),
-        false,
+        options.flag_offline,
         &cargo_home_path,
         &[],
         &[],


### PR DESCRIPTION
It seems that `TempProject::find_updates` calls `SourceId::load` to get a registry for queries, but that function doesn't pay attention to registry overrides in the config. `SourceConfigMap::load` *does* take them into account, and everything else seems to work fine once the override is correctly configured.

I tested this by adding `127.0.0.1     localhost` to `/etc/hosts` to prevent cargo from accessing the servers. ~~I intend to add a more thorough test for CI here but wanted to make sure this seems like the right fix to maintainers beforehand.~~ It looks like CI isn't running much in the way of tests so I'm hesitant to build out a whole harness just for this, let me know what your preference is.

EDIT: For context, the motivation here is to allow isolated CI testing of a crate update workflow tool without taking a dependency on crates.io itself.