### PR TITLE
Fix acquiring package cache lock for SourceConfigMap

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -63,3 +63,29 @@ jobs:
         run: cargo test --no-run ${{ env.FLAGS }}
       - name: Test
         run: cargo test ${{ env.FLAGS }}
+  run:
+    name: Run cargo-outdated
+    env:
+      FLAGS: --all-features
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        rust: [stable]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Cache Builds
+        uses: Swatinem/rust-cache@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Compile
+        run: cargo build ${{ env.FLAGS }}
+      - name: Test
+        run: cargo run ${{ env.FLAGS }} -- outdated
+      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,18 @@ jobs:
         with:
           command: test
           args: --target ${{ matrix.target }} --all-features --release
+      - name: Run
+        uses: actions-rs/cargo@v1
+        if: matrix.features == 'none'
+        with:
+          command: run
+          args: --target ${{ matrix.target }} --no-default-features -- outdated
+      - name: Run release
+        uses: actions-rs/cargo@v1
+        if: matrix.features == 'release'
+        with:
+          command: run
+          args: --target ${{ matrix.target }} --all-features --release -- outdated
   nightly:
     name: Nightly Tests
     strategy:
@@ -166,3 +178,15 @@ jobs:
         with:
           command: test
           args: --all-features --release
+      - name: Run
+        uses: actions-rs/cargo@v1
+        if: matrix.features == 'none'
+        with:
+          command: run
+          args: --target ${{ matrix.target }} --no-default-features -- outdated
+      - name: Run release
+        uses: actions-rs/cargo@v1
+        if: matrix.features == 'release'
+        with:
+          command: run
+          args: --target ${{ matrix.target }} --all-features --release -- outdated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-outdated"
-version = "0.9.17"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "cargo",


### PR DESCRIPTION
Fixes #291.

`Source::query_vec()` requires that the `Config` package lock is held or it panics. The way this works is strange, however. The lock itself is a filesystem lock - it creates the file `.cargo/.package-cache`. `acquire_package_cache_lock()` says that it can be acquired recursively:

>Acquires an exclusive lock on the global "package cache"
>
>This lock is global per-process and can be acquired recursively. An RAII structure is returned to release the lock, and if this abnormally terminates the lock is also released.

However, the way this is implemented is that each `Config` has its own `package_cache_lock`. If you try to acquire locks on two different `Config`s it deadlocks. So I removed the two `self.config` locks and moved it all into a larger scope that holds a lock on the workspace config. I don't know the motivation behind the previous locking of `self.config` but this seems to work.

I also changed CI to run `cargo outdated` on this repo to try to catch errors like this in the future.