### PR TITLE
uses clap for the CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ version = "0.10.2"
 dependencies = [
  "anyhow",
  "cargo",
- "docopt",
+ "clap",
  "env_logger",
  "git2-curl",
  "semver",
@@ -220,7 +220,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim 0.8.0",
+ "strsim",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -334,18 +334,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
  "winapi",
-]
-
-[[package]]
-name = "docopt"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3f119846c823f9eafcf953a8f6ffb6ed69bf6240883261a7f13b634579a51f"
-dependencies = [
- "lazy_static",
- "regex",
- "serde",
- "strsim 0.10.0",
 ]
 
 [[package]]
@@ -1034,12 +1022,6 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ name = "cargo-outdated"
 [dependencies]
 anyhow = "1.0"
 cargo = "0.57.0"
-docopt = "1.1.0"
 env_logger = "0.9.0"
 git2-curl = "0.14.0"
 semver = "1.0.0"
@@ -40,6 +39,7 @@ serde_json = "1.0.56"
 tabwriter = "1.2.1"
 tempfile = "3"
 toml = "~0.5.0"
+clap = "2.33.3"
 
 [dependencies.termcolor]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Ricky H. <ricky.hosfelt@gmail.com>",
 ]
 categories = ["development-tools", "development-tools::cargo-plugins"]
-edition = "2018"
+edition = "2021"
 exclude = ["*.png"]
 keywords = [
     "cargo",

--- a/src/cargo_ops/elaborate_workspace.rs
+++ b/src/cargo_ops/elaborate_workspace.rs
@@ -66,7 +66,7 @@ impl<'ela> ElaborateWorkspace<'ela> {
     ) -> CargoResult<ElaborateWorkspace<'ela>> {
         // new in cargo 0.54.0
         let flag_features: BTreeSet<FeatureValue> = options
-            .flag_features
+            .features
             .iter()
             .map(|feature| FeatureValue::new(InternedString::from(feature)))
             .collect();
@@ -118,13 +118,13 @@ impl<'ela> ElaborateWorkspace<'ela> {
             pkgs,
             pkg_deps,
             pkg_status: RefCell::new(HashMap::new()),
-            workspace_mode: options.flag_workspace || workspace.current().is_err(),
+            workspace_mode: options.workspace || workspace.current().is_err(),
         })
     }
 
     /// Determine root package based on current workspace and CLI options
     pub fn determine_root(&self, options: &Options) -> CargoResult<PackageId> {
-        if let Some(ref root_name) = options.flag_root {
+        if let Some(ref root_name) = options.root {
             if let Ok(workspace_root) = self.workspace.current() {
                 if root_name == workspace_root.name().as_str() {
                     Ok(workspace_root.package_id())
@@ -239,7 +239,7 @@ impl<'ela> ElaborateWorkspace<'ela> {
             self.pkg_status.borrow_mut().insert(path.clone(), status);
             // next layer
             // this unwrap is safe since we first check if it is None :)
-            if options.flag_depth.is_none() || depth < options.flag_depth.unwrap() {
+            if options.depth.is_none() || depth < options.depth.unwrap() {
                 self.pkg_deps[pkg]
                     .keys()
                     .filter(|dep| !path.contains(dep))
@@ -279,7 +279,7 @@ impl<'ela> ElaborateWorkspace<'ela> {
             let pkg = path.last().ok_or(OutdatedError::EmptyPath)?;
             let name = pkg.name().to_string();
 
-            if options.flag_ignore.contains(&name) {
+            if options.ignore.contains(&name) {
                 continue;
             }
 
@@ -287,7 +287,7 @@ impl<'ela> ElaborateWorkspace<'ela> {
             // generate lines
             let status = &self.pkg_status.borrow_mut()[&path];
             if (status.compat.is_changed() || status.latest.is_changed())
-                && (options.flag_packages.is_empty() || options.flag_packages.contains(&name))
+                && (options.packages.is_empty() || options.packages.contains(&name))
             {
                 // name version compatible latest kind platform
                 let parent = path.get(path.len() - 2);
@@ -326,7 +326,7 @@ impl<'ela> ElaborateWorkspace<'ela> {
             }
             // next layer
             // this unwrap is safe since we first check if it is None :)
-            if options.flag_depth.is_none() || depth < options.flag_depth.unwrap() {
+            if options.depth.is_none() || depth < options.depth.unwrap() {
                 self.pkg_deps[pkg]
                     .keys()
                     .filter(|dep| !path.contains(dep))
@@ -379,7 +379,7 @@ impl<'ela> ElaborateWorkspace<'ela> {
             let pkg = path.last().ok_or(OutdatedError::EmptyPath)?;
             let name = pkg.name().to_string();
 
-            if options.flag_ignore.contains(&name) {
+            if options.ignore.contains(&name) {
                 continue;
             }
 
@@ -387,7 +387,7 @@ impl<'ela> ElaborateWorkspace<'ela> {
             // generate lines
             let status = &self.pkg_status.borrow_mut()[&path];
             if (status.compat.is_changed() || status.latest.is_changed())
-                && (options.flag_packages.is_empty() || options.flag_packages.contains(&name))
+                && (options.packages.is_empty() || options.packages.contains(&name))
             {
                 // name version compatible latest kind platform
                 // safely get the parent index
@@ -438,7 +438,7 @@ impl<'ela> ElaborateWorkspace<'ela> {
             }
             // next layer
             // this unwrap is safe since we first check if it is None :)
-            if options.flag_depth.is_none() || depth < options.flag_depth.unwrap() {
+            if options.depth.is_none() || depth < options.depth.unwrap() {
                 self.pkg_deps[pkg]
                     .keys()
                     .filter(|dep| !path.contains(dep))

--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -189,11 +189,11 @@ impl<'tmp> TempProject<'tmp> {
         let mut config = Config::new(shell, cwd, homedir);
         config.configure(
             0,
-            options.flag_verbose == 0,
-            options.flag_color.as_deref(),
+            options.verbose == 0,
+            Some(&options.color.to_string().to_ascii_lowercase()),
             options.frozen(),
             options.locked(),
-            options.flag_offline,
+            options.offline,
             &cargo_home_path,
             &[],
             &[],
@@ -396,7 +396,7 @@ impl<'tmp> TempProject<'tmp> {
             } else if find_latest {
                 // this unwrap is safe since we check if `version_req` is `None` before this
                 // (which is only `None` if `requirement` is `None`)
-                self.options.flag_aggressive
+                self.options.aggressive
                     || valid_latest_version(requirement.unwrap(), summary.version())
             } else {
                 // this unwrap is safe since we check if `version_req` is `None` before this
@@ -436,12 +436,7 @@ impl<'tmp> TempProject<'tmp> {
         if self.options.all_features() {
             return true;
         }
-        if !optional
-            && self
-                .options
-                .flag_features
-                .contains(&String::from("default"))
-        {
+        if !optional && self.options.features.contains(&String::from("default")) {
             return true;
         }
         let features_table = match *features_table {
@@ -450,7 +445,7 @@ impl<'tmp> TempProject<'tmp> {
         };
         let mut to_resolve: Vec<&str> = self
             .options
-            .flag_features
+            .features
             .iter()
             .filter(|f| !f.is_empty())
             .map(String::as_str)
@@ -495,7 +490,7 @@ impl<'tmp> TempProject<'tmp> {
             // In short this allows cargo to build the package with semver minor compatibilities issues
             // https://github.com/rust-lang/cargo/issues/6584
             // https://github.com/kbknapp/cargo-outdated/issues/230
-            if self.options.flag_exclude.contains(&dep_key) {
+            if self.options.exclude.contains(&dep_key) {
                 continue;
             }
 
@@ -682,13 +677,11 @@ impl<'tmp> TempProject<'tmp> {
 
     fn warn<T: ::std::fmt::Display>(&self, message: T) -> CargoResult<()> {
         let original_verbosity = self.config.shell().verbosity();
-        self.config
-            .shell()
-            .set_verbosity(if self.options.flag_quiet {
-                Verbosity::Quiet
-            } else {
-                Verbosity::Normal
-            });
+        self.config.shell().set_verbosity(if self.options.quiet {
+            Verbosity::Quiet
+        } else {
+            Verbosity::Normal
+        });
         self.config.shell().warn(message)?;
         self.config.shell().set_verbosity(original_verbosity);
         Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,243 @@
+use clap::{
+    arg_enum, crate_version, value_t, value_t_or_exit, App, AppSettings, Arg, ArgMatches,
+    SubCommand,
+};
+
+arg_enum! {
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub enum Format {
+        List,
+        Json,
+    }
+}
+
+arg_enum! {
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub enum Color {
+        Auto,
+        Never,
+        Always
+    }
+}
+
+/// Options from CLI arguments
+#[derive(Debug)]
+pub struct Options {
+    pub format: Format,
+    pub color: Color,
+    pub features: Vec<String>,
+    pub ignore: Vec<String>,
+    pub exclude: Vec<String>,
+    pub manifest_path: Option<String>,
+    pub quiet: bool,
+    pub verbose: u64,
+    pub exit_code: i32,
+    pub packages: Vec<String>,
+    pub root: Option<String>,
+    pub depth: Option<i32>,
+    pub root_deps_only: bool,
+    pub workspace: bool,
+    pub aggressive: bool,
+    pub offline: bool,
+}
+
+impl Options {
+    pub fn all_features(&self) -> bool { self.features.is_empty() }
+
+    pub fn no_default_features(&self) -> bool {
+        !(self.features.is_empty() || self.features.contains(&"default".to_owned()))
+    }
+
+    pub fn locked(&self) -> bool { false }
+
+    pub fn frozen(&self) -> bool { false }
+}
+
+impl<'a> From<&ArgMatches<'a>> for Options {
+    fn from(m: &ArgMatches<'a>) -> Self {
+        let mut opts = Options {
+            format: value_t_or_exit!(m.value_of("format"), Format),
+            color: value_t_or_exit!(m.value_of("color"), Color),
+            features: m
+                .values_of("features")
+                .map(|vals| {
+                    vals.flat_map(|x| x.split_ascii_whitespace().collect::<Vec<_>>())
+                        .map(ToOwned::to_owned)
+                        .collect()
+                })
+                .unwrap_or_else(Vec::new),
+            ignore: m
+                .values_of("ignore")
+                .map(|vals| {
+                    vals.flat_map(|x| x.split_ascii_whitespace().collect::<Vec<_>>())
+                        .map(ToOwned::to_owned)
+                        .collect()
+                })
+                .unwrap_or_else(Vec::new),
+            exclude: m
+                .values_of("exclude")
+                .map(|vals| {
+                    vals.flat_map(|x| x.split_ascii_whitespace().collect::<Vec<_>>())
+                        .map(ToOwned::to_owned)
+                        .collect()
+                })
+                .unwrap_or_else(Vec::new),
+            manifest_path: m.value_of("manifest-path").map(ToOwned::to_owned),
+            quiet: m.is_present("quiet"),
+            verbose: m.occurrences_of("verbose"),
+            exit_code: value_t!(m, "exit-code", i32).ok().unwrap_or(0),
+            packages: m
+                .values_of("packages")
+                .map(|vals| {
+                    vals.flat_map(|x| x.split_ascii_whitespace().collect::<Vec<_>>())
+                        .map(ToOwned::to_owned)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_else(Vec::new),
+            root: m.value_of("root").map(ToOwned::to_owned),
+            depth: value_t!(m, "depth", i32).ok(),
+            root_deps_only: m.is_present("root-deps-only"),
+            workspace: m.is_present("workspace"),
+            aggressive: m.is_present("aggressive"),
+            offline: m.is_present("offline"),
+        };
+
+        if m.is_present("root-deps-only") {
+            opts.depth = Some(1);
+        }
+
+        opts
+    }
+}
+
+pub fn parse() -> Options {
+    let matches = App::new("cargo-outdated")
+        .bin_name("cargo")
+        .setting(AppSettings::SubcommandRequired)
+        .subcommand(
+            SubCommand::with_name("outdated")
+                .setting(AppSettings::UnifiedHelpMessage)
+                .about("Displays information about project dependency versions")
+                .version(crate_version!())
+                .arg(
+                    Arg::with_name("aggressive")
+                        .short("a")
+                        .long("aggresssive")
+                        .help("Ignores channels for latest updates"),
+                )
+                .arg(
+                    Arg::with_name("quiet")
+                        .short("q")
+                        .long("quiet")
+                        .help("Suppresses warnings"),
+                )
+                .arg(
+                    Arg::with_name("root-deps-only")
+                        .short("R")
+                        .long("root-deps-only")
+                        .help("Only check root dependencies (Equivalent to --depth=1)"),
+                )
+                .arg(
+                    Arg::with_name("workspace")
+                        .short("w")
+                        .long("workspace")
+                        .help("Checks updates for all workspace members rather than only the root package"),
+                )
+                .arg(
+                    Arg::with_name("offline")
+                        .short("o")
+                        .long("offline")
+                        .help("Run without accessing the network (useful for testing w/ local registries)"),
+                )
+                .arg(
+                    Arg::with_name("format")
+                        .long("format")
+                        .default_value("list")
+                        .case_insensitive(true)
+                        .possible_values(&Format::variants())
+                        .value_name("FORMAT")
+                        .help("Output formatting"),
+                )
+                .arg(
+                    Arg::with_name("ignore")
+                        .short("i")
+                        .long("ignore")
+                        .help("Dependencies to not print in the output (comma separated or one per '--ignore' argument)")
+                        .value_delimiter(",")
+                        .number_of_values(1)
+                        .multiple(true)
+                        .value_name("DEPENDENCIES"),
+                )
+                .arg(
+                    Arg::with_name("exclude")
+                        .short("x")
+                        .long("exclude")
+                        .help("Dependencies to exclude from building (comma separated or one per '--exclude' argument)")
+                        .value_delimiter(",")
+                        .multiple(true)
+                        .number_of_values(1)
+                        .value_name("DEPENDENCIES"),
+                )
+                .arg(
+                    Arg::with_name("verbose")
+                        .short("v")
+                        .long("verbose")
+                        .multiple(true)
+                        .help("Use verbose output")
+                )
+                .arg(
+                    Arg::with_name("color")
+                        .long("color")
+                        .possible_values(&Color::variants())
+                        .default_value("auto")
+                        .value_name("COLOR")
+                        .case_insensitive(true)
+                        .help("Output coloring")
+                )
+                .arg(
+                    Arg::with_name("depth")
+                        .short("d")
+                        .long("depth")
+                        .value_name("NUM")
+                        .help("How deep in the dependency chain to search (Defaults to all dependencies when omitted)")
+                )
+                .arg(
+                    Arg::with_name("exit-code")
+                        .long("exit-code")
+                        .help("The exit code to return on new versions found")
+                        .default_value("0")
+                        .value_name("NUM"))
+                .arg(
+                    Arg::with_name("manifest-path")
+                        .short("m")
+                        .long("manifest-path")
+                        .help("Path to the Cargo.toml file to use (Defaults to Cargo.toml in project root)")
+                        .value_name("PATH"))
+                .arg(
+                    Arg::with_name("root")
+                        .short("r")
+                        .long("root")
+                        .help("Package to treat as the root package")
+                        .value_name("ROOT"))
+                .arg(
+                    Arg::with_name("packages")
+                        .short("p")
+                        .long("packages")
+                        .help("Packages to inspect for updates (comma separated or one per '--packages' argument)")
+                        .value_delimiter(",")
+                        .number_of_values(1)
+                        .multiple(true)
+                        .value_name("PKGS"))
+                .arg(
+                    Arg::with_name("features")
+                        .long("features")
+                        .value_delimiter(",")
+                        .help("Space-separated list of features")
+                        .multiple(true)
+                        .number_of_values(1)
+                        .value_name("FEATURES"))
+            )
+        .get_matches();
+
+    Options::from(matches.subcommand_matches("outdated").unwrap())
+}


### PR DESCRIPTION
Re-introduces `clap` as a dependency and removes `docopt`.

There are a few motivating factors:

- When `cargo-outdated` was originally created, it used `clap`
- When `cargo` became a dependency of `cargo-oudated` the CLI parser was
   changed to `docopt` because that's what `cargo` used.
- Since that time, `cargo` has changed it's CLI parser to `clap`
- [`docopt` has been effectively unmaintained for  years](https://github.com/clap-rs/clap/issues/2951#issuecomment-952882684), which is also noted in their README

This commit shaves ~31 seconds off the compile time on my CPU (Intel i9-9980HK). I
haven't dug into this, but I'm assuming because it's able to re-use the
`clap` compiled as for both `cargo-oudated` and `cargo` in the dep graph
(more on this below). It also seems to have removed some duplicate deps
with different versions.

Why use clap 2.x instead of clap 3.x or Structopt? Because that's what
`cargo` is using so we are able to re-use the compilation between. This
would still be the case with Structopt. However, with clap v3 on the
horizon (fingers crossed) I'd prefer to just upgrade at that point
instead of worrying about any differences. Plus any gains in compile time
would possibly be reversed by using Structopt's Custom Derive (same with clap v3
eventually).

Finally, the tests that were recently added ensured that the CLI UX didn't change between these two parsers. clap however adds quite few new features, and also opens the possibilities for quickly adding shell completions, etc.