### PR TITLE
fix(285): Added switch ignore-external-rel to workaround issue 285

### DIFF
--- a/src/cargo_ops/elaborate_workspace.rs
+++ b/src/cargo_ops/elaborate_workspace.rs
@@ -206,7 +206,7 @@ impl<'ela> ElaborateWorkspace<'ela> {
         options: &Options,
         _config: &Config,
         root: PackageId,
-        skip: &HashSet<String>
+        skip: &HashSet<String>,
     ) -> CargoResult<()> {
         self.pkg_status.borrow_mut().clear();
         let (compat_root, latest_root) = if self.workspace_mode {
@@ -236,7 +236,7 @@ impl<'ela> ElaborateWorkspace<'ela> {
                 compat_pkg,
                 latest_pkg,
                 status
-            );        
+            );
             self.pkg_status.borrow_mut().insert(path.clone(), status);
             // next layer
             // this unwrap is safe since we first check if it is None :)
@@ -244,9 +244,7 @@ impl<'ela> ElaborateWorkspace<'ela> {
                 self.pkg_deps[pkg]
                     .keys()
                     .filter(|dep| !path.contains(dep))
-                    .filter(|&dep| {
-                        !skip.contains(dep.name().as_str())
-                    })
+                    .filter(|&dep| !skip.contains(dep.name().as_str()))
                     .for_each(|&dep| {
                         let name = dep.name();
                         let compat_pkg = compat_pkg
@@ -339,9 +337,7 @@ impl<'ela> ElaborateWorkspace<'ela> {
                         !self.workspace_mode
                             || !self.workspace.members().any(|mem| &mem.package_id() == dep)
                     })
-                    .filter(|&dep| {
-                        !skip.contains(dep.name().as_str())
-                    })
+                    .filter(|&dep| !skip.contains(dep.name().as_str()))
                     .for_each(|&dep| {
                         let mut path = path.clone();
                         path.push(dep);
@@ -375,7 +371,12 @@ impl<'ela> ElaborateWorkspace<'ela> {
         Ok(lines.len() as i32)
     }
 
-    pub fn print_json(&'ela self, options: &Options, root: PackageId, skip: &HashSet<String>) -> CargoResult<i32> {
+    pub fn print_json(
+        &'ela self,
+        options: &Options,
+        root: PackageId,
+        skip: &HashSet<String>,
+    ) -> CargoResult<i32> {
         let mut crate_graph = CrateMetadata {
             crate_name: root.name().to_string(),
             dependencies: BTreeSet::new(),
@@ -455,9 +456,7 @@ impl<'ela> ElaborateWorkspace<'ela> {
                                 .members()
                                 .any(|mem| mem.package_id() == **dep)
                     })
-                    .filter(|&dep| {
-                        !skip.contains(dep.name().as_str())
-                    })
+                    .filter(|&dep| !skip.contains(dep.name().as_str()))
                     .for_each(|dep| {
                         let mut path = path.clone();
                         path.push(*dep);

--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -228,9 +228,9 @@ impl<'tmp> TempProject<'tmp> {
         Ok(())
     }
 
-    fn manipulate_dependencies<F>(manifest: &mut Manifest, f: &F) -> CargoResult<()>
+    fn manipulate_dependencies<F>(manifest: &mut Manifest, f: &mut F) -> CargoResult<()>
     where
-        F: Fn(&mut Table) -> CargoResult<()>,
+        F: FnMut(&mut Table) -> CargoResult<()>,
     {
         if let Some(dep) = manifest.dependencies.as_mut() {
             f(dep)?;
@@ -265,6 +265,7 @@ impl<'tmp> TempProject<'tmp> {
         orig_root: P,
         tmp_root: P,
         workspace: &ElaborateWorkspace<'_>,
+        skipped: &mut HashSet<String>,
     ) -> CargoResult<()> {
         let bin = {
             let mut bin = Table::new();
@@ -286,19 +287,20 @@ impl<'tmp> TempProject<'tmp> {
             if let Some(lib) = manifest.lib.as_mut() {
                 lib.insert("path".to_owned(), Value::String("test_lib.rs".to_owned()));
             }
-            Self::manipulate_dependencies(&mut manifest, &|deps| {
+            Self::manipulate_dependencies(&mut manifest, &mut |deps| {
                 Self::replace_path_with_absolute(
                     self,
                     deps,
                     orig_root.as_ref(),
                     tmp_root.as_ref(),
                     manifest_path,
+                    skipped,
                 )
             })?;
 
             let package_name = manifest.name();
             let features = manifest.features.clone();
-            Self::manipulate_dependencies(&mut manifest, &|deps| {
+            Self::manipulate_dependencies(&mut manifest, &mut |deps| {
                 self.update_version_and_feature(deps, &features, workspace, &package_name, false)
             })?;
 
@@ -317,6 +319,7 @@ impl<'tmp> TempProject<'tmp> {
         orig_root: P,
         tmp_root: P,
         workspace: &ElaborateWorkspace<'_>,
+        skipped: &mut HashSet<String>,
     ) -> CargoResult<()> {
         let bin = {
             let mut bin = Table::new();
@@ -337,20 +340,23 @@ impl<'tmp> TempProject<'tmp> {
             if let Some(lib) = manifest.lib.as_mut() {
                 lib.insert("path".to_owned(), Value::String("test_lib.rs".to_owned()));
             }
-            Self::manipulate_dependencies(&mut manifest, &|deps| {
+            Self::manipulate_dependencies(&mut manifest, &mut |deps| {
                 Self::replace_path_with_absolute(
                     self,
                     deps,
                     orig_root.as_ref(),
                     tmp_root.as_ref(),
                     manifest_path,
+                    skipped,
                 )
             })?;
+
             let package_name = manifest.name();
             let features = manifest.features.clone();
-            Self::manipulate_dependencies(&mut manifest, &|deps| {
+            Self::manipulate_dependencies(&mut manifest, &mut |deps| {
                 self.update_version_and_feature(deps, &features, workspace, &package_name, true)
             })?;
+            
             Self::write_manifest(&manifest, manifest_path)?;
         }
 
@@ -633,6 +639,7 @@ impl<'tmp> TempProject<'tmp> {
         orig_root: &Path,
         tmp_root: &Path,
         tmp_manifest: &Path,
+        skipped: &mut HashSet<String>,
     ) -> CargoResult<()> {
         let dep_names: Vec<_> = dependencies.keys().cloned().collect();
         for name in dep_names {
@@ -642,7 +649,7 @@ impl<'tmp> TempProject<'tmp> {
                 .ok_or(OutdatedError::NoMatchingDependency)?;
             match original {
                 Value::Table(ref t) if t.contains_key("path") => {
-                    if let Value::String(ref orig_path) = t["path"] {
+                    if let Value::String(ref orig_path) = t["path"] {                        
                         let orig_path = Path::new(orig_path);
                         if orig_path.is_relative() {
                             let relative = {
@@ -655,16 +662,32 @@ impl<'tmp> TempProject<'tmp> {
                                 relative.join(orig_path)
                             };
                             if !tmp_root.join(&relative).join("Cargo.toml").exists() {
-                                let mut replaced = t.clone();
-                                replaced.insert(
-                                    "path".to_owned(),
-                                    Value::String(
-                                        fs::canonicalize(orig_root.join(relative))?
-                                            .to_string_lossy()
-                                            .to_string(),
-                                    ),
-                                );
-                                dependencies.insert(name, Value::Table(replaced));
+                                if self.options.root_deps_only {
+                                    dependencies.remove(&name);
+
+                                    if t.contains_key("package") {
+                                        if let Value::String(ref package_name) = t["package"] {
+                                            skipped.insert(package_name.to_string());
+                                        } else {
+                                            skipped.insert(name);
+                                        }
+                                    }
+                                    else {
+                                        skipped.insert(name);
+                                    }            
+
+                                } else {
+                                    let mut replaced = t.clone();
+                                    replaced.insert(
+                                        "path".to_owned(),
+                                        Value::String(
+                                            fs::canonicalize(orig_root.join(relative))?
+                                                .to_string_lossy()
+                                                .to_string(),
+                                        ),
+                                    );
+                                    dependencies.insert(name, Value::Table(replaced));
+                                }
                             }
                         }
                     }

--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -356,7 +356,7 @@ impl<'tmp> TempProject<'tmp> {
             Self::manipulate_dependencies(&mut manifest, &mut |deps| {
                 self.update_version_and_feature(deps, &features, workspace, &package_name, true)
             })?;
-            
+
             Self::write_manifest(&manifest, manifest_path)?;
         }
 
@@ -649,7 +649,7 @@ impl<'tmp> TempProject<'tmp> {
                 .ok_or(OutdatedError::NoMatchingDependency)?;
             match original {
                 Value::Table(ref t) if t.contains_key("path") => {
-                    if let Value::String(ref orig_path) = t["path"] {                        
+                    if let Value::String(ref orig_path) = t["path"] {
                         let orig_path = Path::new(orig_path);
                         if orig_path.is_relative() {
                             let relative = {
@@ -671,11 +671,9 @@ impl<'tmp> TempProject<'tmp> {
                                         } else {
                                             skipped.insert(name);
                                         }
-                                    }
-                                    else {
+                                    } else {
                                         skipped.insert(name);
-                                    }            
-
+                                    }
                                 } else {
                                     let mut replaced = t.clone();
                                     replaced.insert(


### PR DESCRIPTION
Closes #285

If you use `cargo outdated` on a workspace with relative dependencies referring to a package that is external to the workspace, `cargo outdated` will convert to the reference to an absolute path reference. This however fails is the external project (or one of its' dependencies) have a relative dependency back to a package in the workspace, as you now have the same package in two different places (both the temp one and the original one). 

This proposed switch mitigates this problem by skipping all dependencies that are relative and outside the workspace - basically all that would otherwise have been converted into absolute path dependencies.
When elaborating the result, the switch will omit reporting package that have been removed (since they were skipped). Transitive dependencies are not considering as this switch will enforce `--depth=1`.