### PR TITLE
fix: Typo in `--aggressive` arg

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -137,7 +137,7 @@ fn build() -> App<'static, 'static> {
                 .arg(
                     Arg::with_name("aggressive")
                         .short("a")
-                        .long("aggresssive")
+                        .long("aggressive")
                         .help("Ignores channels for latest updates"),
                 )
                 .arg(


### PR DESCRIPTION
I am not sure if this should be considered a breaking change, i.e. if this arg is being used in scripts this way?