### PR TITLE
Metadata and CI update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,60 +13,29 @@ jobs:
   test:
     name: Tests
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         rust: [stable, beta]
         os: [windows-latest, macOS-latest, ubuntu-latest]
         target:
-          - i686-pc-windows-msvc
           - x86_64-pc-windows-msvc
-          - i686-pc-windows-gnu
           - x86_64-pc-windows-gnu
           - x86_64-unknown-linux-gnu
-          - i686-unknown-linux-gnu
           - x86_64-apple-darwin
-        features:
-          - none
-          - all
-          - release
         exclude:
-          - features: release
-            rust: stable
-          - features: release
-            rust: beta
-          # Vendored OpenSSL only supported on Linux
-          - os: macOS-latest
-            features: all
-          - os: windows-latest
-            features: all
-          # There's some cross-compile issues with libssl (for now?)
-          - os: ubuntu-latest
-            target: i686-unknown-linux-gnu
           # Exclude combinations that don't make sense
           - os: windows-latest
             target: x86_64-apple-darwin
           - os: windows-latest
             target: x86_64-unknown-linux-gnu
-          - os: windows-latest
-            target: i686-unknown-linux-gnu
-          - os: macos-latest
-            target: i686-pc-windows-msvc
           - os: macos-latest
             target: x86_64-pc-windows-msvc
-          - os: macos-latest
-            target: i686-pc-windows-gnu
           - os: macos-latest
             target: x86_64-pc-windows-gnu
           - os: macos-latest
             target: x86_64-unknown-linux-gnu
-          - os: macos-latest
-            target: i686-unknown-linux-gnu
-          - os: ubuntu-latest
-            target: i686-pc-windows-msvc
           - os: ubuntu-latest
             target: x86_64-pc-windows-msvc
-          - os: ubuntu-latest
-            target: i686-pc-windows-gnu
           - os: ubuntu-latest
             target: x86_64-pc-windows-gnu
           - os: ubuntu-latest
@@ -82,115 +51,15 @@ jobs:
           override: true
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install linker
-        if: matrix.target == 'i686-pc-windows-gnu'
-        uses: egor-tensin/setup-mingw@v2
-        with:
-          platform: x86
+      - name: Install Just
+        run: cargo install just cargo-nextest
       - name: Install linker
         if: matrix.target == 'x86_64-pc-windows-gnu'
         uses: egor-tensin/setup-mingw@v2
-      - name: Install linker
-        if: matrix.target == 'i686-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install gcc-multilib
       - name: OpenSSL Libs
-        if: matrix.os == 'ubuntu-latest' && matrix.features == 'all'
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install libssl-dev
-      - name: Test almost no features
-        uses: actions-rs/cargo@v1
-        if: matrix.features == 'none'
-        with:
-          command: test
-          args: --target ${{ matrix.target }} --no-default-features
-      - name: Test all features
-        uses: actions-rs/cargo@v1
-        if: matrix.features == 'all'
-        with:
-          command: test
-          args: --target ${{ matrix.target }} --all-features
-      - name: Check debug
-        uses: actions-rs/cargo@v1
-        if: matrix.features == 'all'
-        with:
-          command: check
-          args: --target ${{ matrix.target }} --all-features
-      - name: Test release
-        uses: actions-rs/cargo@v1
-        if: matrix.features == 'release'
-        with:
-          command: test
-          args: --target ${{ matrix.target }} --all-features --release
-      - name: Run
-        uses: actions-rs/cargo@v1
-        continue-on-error: true
-        if: matrix.features == 'none'
-        with:
-          command: run
-          args: --target ${{ matrix.target }} --no-default-features -- outdated
-      - name: Run release
-        uses: actions-rs/cargo@v1
-        if: matrix.features == 'release'
-        continue-on-error: true
-        with:
-          command: run
-          args: --target ${{ matrix.target }} --all-features --release -- outdated
-  nightly:
-    name: Nightly Tests
-    strategy:
-      fail-fast: false
-      matrix:
-        features:
-          - none
-          - all
-          - release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Test almost no features
-        uses: actions-rs/cargo@v1
-        if: matrix.features == 'none'
-        with:
-          command: test
-          args: --no-default-features
-      - name: Test all features
-        uses: actions-rs/cargo@v1
-        if: matrix.features == 'all'
-        with:
-          command: test
-          args: --all-features
-      - name: Check debug
-        uses: actions-rs/cargo@v1
-        if: matrix.features == 'all'
-        with:
-          command: check
-          args: --all-features
-      - name: Test release
-        uses: actions-rs/cargo@v1
-        if: matrix.features == 'release'
-        with:
-          command: test
-          args: --all-features --release
-      - name: Run
-        uses: actions-rs/cargo@v1
-        continue-on-error: true
-        if: matrix.features == 'none'
-        with:
-          command: run
-          args: --no-default-features -- outdated
-      - name: Run release
-        uses: actions-rs/cargo@v1
-        continue-on-error: true
-        if: matrix.features == 'release'
-        with:
-          command: run
-          args: --all-features --release -- outdated
+      - name: Test
+        run: just test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,11 @@
-name: deploy
-
+name: release
 on:
   push:
     tags:
       - 'v*.*.*'
-
 jobs:
-
   create-windows-binaries:
-
     runs-on: windows-latest
-
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,8 +18,7 @@ jobs:
         rust:
           - nightly
           - 1.65.0 # MSRV
-          # There are not lints we need to perform on stable
-          #- stable
+          - stable
 
     steps:
       - uses: actions/checkout@v2
@@ -51,7 +50,7 @@ jobs:
         run: just fmt-check
 
       - name: Clippy
-        if: ${{ matrix.rust == 'nightly' }}
+        if: ${{ matrix.rust == 'stable' }}
         run: just lint
 
       - name: MSRV Check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,9 +16,10 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
           - nightly
-          - 1.59.0 # MSRV
+          - 1.65.0 # MSRV
+          # There are not lints we need to perform on stable
+          #- stable
 
     steps:
       - uses: actions/checkout@v2
@@ -42,11 +43,17 @@ jobs:
         uses: crate-ci/typos@master
 
       - name: Install Just
-        run: cargo install just cargo-nextest
+        if: ${{ matrix.rust == 'nightly' }}
+        run: cargo install just
 
       - name: Check Formatting
         if: ${{ matrix.rust == 'nightly' }}
         run: just fmt-check
 
-      - name: Lint
+      - name: Clippy
+        if: ${{ matrix.rust == 'nightly' }}
         run: just lint
+
+      - name: MSRV Check
+        if: ${{ matrix.rust == '1.65.0' }}
+        run: cargo check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,65 +1,52 @@
 name: Lint
+
 on:
   pull_request:
     branches: [master, main]
   push:
     branches: [staging, trying]
+
 concurrency:
   group: lint-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
-  lint:
-    name: Lint
-    needs: [clippy]
+  ci:
     runs-on: ubuntu-latest
-    steps:
-      - name: Done
-        run: exit 0
-  clippy:
-    name: Clippy
     strategy:
-      fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        rust: [stable]
-    runs-on: ${{ matrix.os }}
+        rust:
+          - stable
+          - nightly
+          - 1.59.0 # MSRV
+
     steps:
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v2
+
+      - name: OpenSSL Libs
+        if: matrix.os == 'ubuntu-latest' && matrix.features == 'all'
+        run: |
+          sudo apt-get update
+          sudo apt-get install libssl-dev
+
+      - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          components: clippy, rustfmt
           toolchain: ${{ matrix.rust }}
           override: true
-          components: clippy
-      - name: Cache Builds
-        uses: Swatinem/rust-cache@v1
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Clippy no features
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --no-default-features -- -D warnings
-      - name: Clippy with all features
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --all-targets --all -- -D warnings
-  format:
-    name: Formatting
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          components: rustfmt
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Format check
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Spell Check
+        uses: crate-ci/typos@master
+
+      - name: Install Just
+        run: cargo install just cargo-nextest
+
+      - name: Check Formatting
+        if: ${{ matrix.rust == 'nightly' }}
+        run: just fmt-check
+
+      - name: Lint
+        run: just lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
         uses: crate-ci/typos@master
 
       - name: Install Just
-        if: ${{ matrix.rust == 'nightly' }}
+        if: ${{ matrix.rust == 'nightly' || matrix.rust == 'stable' }}
         run: cargo install just
 
       - name: Check Formatting

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,2 @@
+[default.extend-identifiers]
+8ba28c73 = "8ba28c73"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+<a name="v0.12.0"></a>
+### v0.12.0 (2023-06-17)
+
+#### Changes
+
+* MSRV is now 1.65.0
+
+#### Improvements
+
+* update to cargo v0.71 (this allows using sparse regitstry protocol :tada:)
+* update to clap v4
+
+#### Maintenance
+
+* Streamline CI and use `just` as the driving command runner
+* Bump deps
+
 <a name="v0.11.2"></a>
 ### v0.11.2 (2023-01-22)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,25 +2,59 @@
 
 Contributions are always welcome! Please use the following guidelines when contributing to `cargo-outdated`
 
-1. Fork `cargo-outdated`
-2. Clone your fork (`git clone https://github.com/$YOUR_USERNAME/cargo-outdated && cd cargo-outdated`)
-3. Create new branch (`git checkout -b new-branch`)
-4. Make your changes, and commit (`git commit -am "your message"`)
- * I use a [conventional](https://github.com/ajoslin/conventional-changelog/blob/master/CONVENTIONS.md) changelog format so I can update my changelog using [clog](https://github.com/clog-tool/clog-cli)
- * Format your commit subject line using the following format: `TYPE(COMPONENT): MESSAGE` where `TYPE` is one of the following:
-    - `feat` - A new feature
-    - `imp` - An improvement to an existing feature
-    - `perf` - A performance improvement
-    - `docs` - Changes to documentation only
-    - `tests` - Changes to the testing framework or tests only
-    - `fix` - A bug fix
-    - `refactor` - Code functionality doesn't change, but underlying structure may
-    - `style` - Stylistic changes only, no functionality changes
-    - `wip` - A work in progress commit (Should typically be `git rebase`'ed away)
-    - `chore` - Catch all or things that have to do with the build system, etc
- * The `COMPONENT` is optional, and may be a single file, directory, or logical component. Can be omitted if commit applies globally
-5. Run the tests (`cargo test`)
-6. `git rebase` into concise commits and remove `--fixup`s (`git rebase -i HEAD~NUM` where `NUM` is number of commits back)
-7. Push your changes back to your fork (`git push origin $your-branch`)
-8. Create a pull request! (You can also create the pull request first, and we'll merge when ready. This a good way to discuss proposed changes.)
+## Justfile
+
+We use [`just`](https://github.com/Casey/just) as a command
+runner which should simplify running the same tests on your
+changes locally that will be run in CI.
+
+After installing `just` (`cargo install`, via Github Release
+binaries, etc.) you can run `just help` to see a list of valid
+targets. Most importantly `just ci` should run the entire CI
+suit against your changes (except only for your native OS and
+architecture).
+
+`just lint` is a good recipe to run while developing to run the
+linting and formatting checks prior to trying to run the entire
+test suite.
+
+At the time of this writing the recipes look like this:
+
+```
+$ just help
+Available recipes:
+    bench $RUSTFLAGS='-Ctarget-cpu=native' # Run benchmarks
+    ci                  # Run all the checks required for CI to pass
+    clean
+    debug TEST
+    default
+    fmt                 # Format the code
+    fmt-check           # Check the formatting of the code but don't actually format it
+    help                # Get a list of recipes you can run
+    lint                # Lint the code
+    run-test TEST
+    run-tests
+    setup               # Install required tools for development
+    spell-check         # Check for typos
+    test TEST_RUNNER='cargo nextest run' # Run the test suite
+    update-contributors
+
+```
+
+## Commit Subjects
+
+As you make your commit messages; please note that we use a [conventional](https://github.com/ajoslin/conventional-changelog/blob/master/CONVENTIONS.md) changelog format so we can update my changelog using [clog](https://github.com/clog-tool/clog-cli)
+
+* Format your commit subject line using the following format: `TYPE(COMPONENT): MESSAGE` where `TYPE` is one of the following:
+  * `feat` - A new feature
+  * `imp` - An improvement to an existing feature
+  * `perf` - A performance improvement
+  * `docs` - Changes to documentation only
+  * `tests` - Changes to the testing framework or tests only
+  * `fix` - A bug fix
+  * `refactor` - Code functionality doesn't change, but underlying structure may
+  * `style` - Stylistic changes only, no functionality changes
+  * `wip` - A work in progress commit (Should typically be `git rebase`'ed away)
+  * `chore` - Catch all or things that have to do with the build system, etc
+* The `COMPONENT` is optional, and may be a single file, directory, or logical component. Can be omitted if commit applies globally
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ dependencies = [
  "tempfile",
  "termcolor",
  "time",
- "toml 0.7.4",
+ "toml",
  "toml_edit",
  "unicode-width",
  "unicode-xid",
@@ -280,7 +280,7 @@ dependencies = [
  "tabwriter",
  "tempfile",
  "termcolor",
- "toml 0.5.11",
+ "toml",
 ]
 
 [[package]]
@@ -2576,15 +2576,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "toml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde_derive = "1.0.114"
 serde_json = "1.0.56"
 tabwriter = "1.2.1"
 tempfile = "3"
-toml = "~0.5.0"
+toml = "0.7.4"
 clap = { version = "4.1.4", features = ["derive"] }
 strum = { version = "0.24.1", features = ["derive"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-outdated"
-version = "0.11.2"
+version = "0.12.0"
 authors = [
     "Kevin K. <kbknapp@gmail.com>",
     "Frederick Z. <frederick888@tsundere.moe>",
@@ -20,9 +20,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/kbknapp/cargo-outdated.git"
 description = "Cargo subcommand for displaying when dependencies are out of date"
-
-[badges]
-travis-ci = {repository = "kbknapp/cargo-outdated"}
+rust-version = "1.65.0" # MSRV
 
 [[bin]]
 name = "cargo-outdated"

--- a/justfile
+++ b/justfile
@@ -12,11 +12,11 @@ ci: spell-check lint test
 
 # Format the code
 fmt:
-    cargo fmt --all
+    cargo +nightly fmt --all
 
 # Check the formatting of the code but don't actually format it
 fmt-check:
-    cargo fmt --all --check
+    cargo +nightly fmt --all --check
 
 # Lint the code
 lint: fmt-check

--- a/justfile
+++ b/justfile
@@ -1,3 +1,42 @@
+default: help
+
+# Get a list of recipes you can run
+@help:
+    just --list
+
+# Install required tools for development
+setup: (_cargo-install 'cargo-nextest') _install-spell-check
+
+# Run all the checks required for CI to pass
+ci: spell-check lint test
+
+# Format the code
+fmt:
+    cargo fmt --all
+
+# Check the formatting of the code but don't actually format it
+fmt-check:
+    cargo fmt --all --check
+
+# Lint the code
+lint: fmt-check
+    cargo clippy --all-targets -- -Dwarnings
+    cargo clippy --all-targets --no-default-features -- -Dwarnings
+    cargo clippy --all-targets --all-features -- -Dwarnings
+
+# Run benchmarks
+bench $RUSTFLAGS='-Ctarget-cpu=native':
+    cargo bench
+
+# Run the test suite
+test TEST_RUNNER='cargo nextest run': setup
+    {{ TEST_RUNNER }}
+    {{ TEST_RUNNER }} --no-default-features
+    {{ TEST_RUNNER }} --all-features
+
+# Check for typos
+spell-check: _install-spell-check
+
 @update-contributors:
 	echo 'Removing old CONTRIBUTORS.md'
 	mv CONTRIBUTORS.md CONTRIBUTORS.md.bak
@@ -20,17 +59,30 @@ debug TEST:
 run-tests:
 	cargo test --features "yaml unstable"
 
-nightly:
-	rustup override add nightly
-
-rm-nightly:
-	rustup override remove
-
-@lint: nightly
-	cargo build --features lints && just rm-nightly
-
 clean:
 	cargo clean
-	find . -type f -name "*.orig" -exec rm {} \;
-	find . -type f -name "*.bk" -exec rm {} \;
-	find . -type f -name ".*~" -exec rm {} \;
+
+##
+#
+# Helpers
+##
+
+[unix]
+_install-spell-check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v typos 2>&1 >/dev/null ; then
+      cargo install typos-cli --force
+    fi
+
+[windows]
+_install-spell-check:
+    #!powershell.exe
+    $ret = Get-Command typos >$null 2>$null
+
+    if (! $?) {
+      cargo install typos-cli --force
+    }
+
+_cargo-install TOOL:
+    cargo install {{TOOL}}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly"
+profile = "default"
+components = ["rust-src", "rustfmt", "clippy", "rust-analyzer"]
+

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,22 @@
-format_strings = false
+# https://rust-lang.github.io/rustfmt/?version=master&search=#edition
+edition = "2021"
+# https://rust-lang.github.io/rustfmt/?version=master&search=#fn_single_line
 fn_single_line = true
-reorder_imports = true
+# https://rust-lang.github.io/rustfmt/?version=master&search=#format_code_in_doc_comments
+format_code_in_doc_comments = true
+# https://rust-lang.github.io/rustfmt/?version=master&search=#format_macro_matchers
+format_macro_matchers = true
+# https://rust-lang.github.io/rustfmt/?version=master&search=#imports_granularity
+imports_granularity = "Crate"
+# https://rust-lang.github.io/rustfmt/?version=master&search=#normalize_comments
+normalize_comments = true
+# https://rust-lang.github.io/rustfmt/?version=master&search=#reorder_impl_items
+reorder_impl_items = true
+# https://rust-lang.github.io/rustfmt/?version=master&search=#unstable_features
+unstable_features = true
+# https://rust-lang.github.io/rustfmt/?version=master&search=#use_field_init_shorthand
+use_field_init_shorthand = true
+# https://rust-lang.github.io/rustfmt/?version=master&search=#use_try_shorthand
+use_try_shorthand = true
+# https://rust-lang.github.io/rustfmt/?version=master&search=#wrap_comments
+wrap_comments = true

--- a/src/cargo_ops/elaborate_workspace.rs
+++ b/src/cargo_ops/elaborate_workspace.rs
@@ -1,25 +1,31 @@
-use std::cell::RefCell;
-use std::cmp::Ordering;
-use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
-use std::io::{self, Write};
-use std::rc::Rc;
+use std::{
+    cell::RefCell,
+    cmp::Ordering,
+    collections::{BTreeSet, HashMap, HashSet, VecDeque},
+    io::{self, Write},
+    rc::Rc,
+};
 
 use anyhow::anyhow;
-use cargo::core::compiler::{CompileKind, RustcTargetData};
-use cargo::core::resolver::features::{ForceAllTargets, HasDevUnits};
-use cargo::core::resolver::CliFeatures;
-use cargo::core::FeatureValue;
-use cargo::core::{dependency::DepKind, Dependency, Package, PackageId, Workspace};
-use cargo::ops::{self, Packages};
-use cargo::util::interning::InternedString;
-use cargo::util::{CargoResult, Config};
+use cargo::{
+    core::{
+        compiler::{CompileKind, RustcTargetData},
+        dependency::DepKind,
+        resolver::{
+            features::{ForceAllTargets, HasDevUnits},
+            CliFeatures,
+        },
+        Dependency, FeatureValue, Package, PackageId, Workspace,
+    },
+    ops::{self, Packages},
+    util::{interning::InternedString, CargoResult, Config},
+};
 use serde::{Deserialize, Serialize};
 use tabwriter::TabWriter;
 
 use crate::error::OutdatedError;
 
-use super::pkg_status::*;
-use super::Options;
+use super::{pkg_status::*, Options};
 
 /// An elaborate workspace containing resolved dependencies and
 /// the update status of packages
@@ -78,8 +84,9 @@ impl<'ela> ElaborateWorkspace<'ela> {
             uses_default_features: options.no_default_features(),
         };
 
-        //The CompileKind, this has no target since it's the temp workspace
-        //targets are blank since we don't need to fully build for the targets to get the dependencies
+        // The CompileKind, this has no target since it's the temp workspace
+        // targets are blank since we don't need to fully build for the targets to get
+        // the dependencies
         let compile_kind = CompileKind::from_requested_targets(workspace.config(), &[])?;
         let target_data = RustcTargetData::new(workspace, &compile_kind)?;
         let ws_resolve = ops::resolve_ws_with_opts(
@@ -160,7 +167,8 @@ impl<'ela> ElaborateWorkspace<'ela> {
         Err(anyhow!("Workspace member {} not found", member.name()))
     }
 
-    /// Find a contained package, which is a member or dependency inside the workspace
+    /// Find a contained package, which is a member or dependency inside the
+    /// workspace
     fn find_contained_package(&self, name: &str) -> CargoResult<PackageId> {
         let root_path = self.workspace.root();
         for (pkg_id, pkg) in &self.pkgs {
@@ -198,7 +206,8 @@ impl<'ela> ElaborateWorkspace<'ela> {
         ))
     }
 
-    /// Resolve compatible and latest status from the corresponding `ElaborateWorkspace`s
+    /// Resolve compatible and latest status from the corresponding
+    /// `ElaborateWorkspace`s
     pub fn resolve_status(
         &'ela self,
         compat: &ElaborateWorkspace<'_>,

--- a/src/cargo_ops/mod.rs
+++ b/src/cargo_ops/mod.rs
@@ -11,36 +11,18 @@ pub use self::{elaborate_workspace::ElaborateWorkspace, pkg_status::*, temp_proj
 struct Manifest {
     #[serde(rename = "cargo-features", skip_serializing_if = "Option::is_none")]
     pub cargo_features: Option<Value>,
-    #[serde(serialize_with = "::toml::ser::tables_last")]
     pub package: Table,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "opt_tables_last"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dependencies: Option<Table>,
-    #[serde(
-        rename = "dev-dependencies",
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "opt_tables_last"
-    )]
+    #[serde(rename = "dev-dependencies", skip_serializing_if = "Option::is_none")]
     pub dev_dependencies: Option<Table>,
-    #[serde(
-        rename = "build-dependencies",
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "opt_tables_last"
-    )]
+    #[serde(rename = "build-dependencies", skip_serializing_if = "Option::is_none")]
     pub build_dependencies: Option<Table>,
     pub lib: Option<Table>,
     pub bin: Option<Vec<Table>>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "opt_tables_last"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace: Option<Table>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "opt_tables_last"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<Table>,
     pub features: Option<Value>,
 }
@@ -51,15 +33,5 @@ impl Manifest {
             Value::String(ref name) => name.clone(),
             _ => unreachable!(),
         }
-    }
-}
-
-pub fn opt_tables_last<S>(data: &Option<Table>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: ::serde::ser::Serializer,
-{
-    match *data {
-        Some(ref d) => ::toml::ser::tables_last(d, serializer),
-        None => unreachable!(),
     }
 }

--- a/src/cargo_ops/mod.rs
+++ b/src/cargo_ops/mod.rs
@@ -4,9 +4,7 @@ use toml::value::{Table, Value};
 mod elaborate_workspace;
 mod pkg_status;
 mod temp_project;
-pub use self::elaborate_workspace::ElaborateWorkspace;
-pub use self::pkg_status::*;
-pub use self::temp_project::TempProject;
+pub use self::{elaborate_workspace::ElaborateWorkspace, pkg_status::*, temp_project::TempProject};
 
 /// A continent struct for quick parsing and manipulating manifest
 #[derive(Debug, serde_derive::Serialize, serde_derive::Deserialize)]

--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -1,25 +1,26 @@
-use std::cell::RefCell;
-use std::collections::HashSet;
-use std::env;
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
-use std::rc::Rc;
+use std::{
+    cell::RefCell,
+    collections::HashSet,
+    env,
+    fs::{self, File, OpenOptions},
+    io::{Read, Write},
+    path::{Path, PathBuf},
+    rc::Rc,
+};
 
 use anyhow::{anyhow, Context};
-use cargo::core::{Dependency, PackageId, QueryKind, Source, Summary, Verbosity, Workspace};
-use cargo::ops::{update_lockfile, UpdateOptions};
-use cargo::sources::config::SourceConfigMap;
-use cargo::util::network::PollExt;
-use cargo::util::{CargoResult, Config};
+use cargo::{
+    core::{Dependency, PackageId, QueryKind, Source, Summary, Verbosity, Workspace},
+    ops::{update_lockfile, UpdateOptions},
+    sources::config::SourceConfigMap,
+    util::{network::PollExt, CargoResult, Config},
+};
 use semver::{Version, VersionReq};
 use tempfile::{Builder, TempDir};
-use toml::value::Table;
-use toml::Value;
+use toml::{value::Table, Value};
 
 use super::{ElaborateWorkspace, Manifest};
-use crate::error::OutdatedError;
-use crate::Options;
+use crate::{error::OutdatedError, Options};
 
 /// A temporary project
 pub struct TempProject<'tmp> {
@@ -68,7 +69,7 @@ impl<'tmp> TempProject<'tmp> {
             tmp_manifest_paths.push(dest.clone());
             fs::copy(from, &dest)?;
 
-            //removing default-run key if it exists to check dependencies
+            // removing default-run key if it exists to check dependencies
             let mut om: Manifest = {
                 let mut buf = String::new();
                 let mut file = File::open(&dest)?;
@@ -87,8 +88,8 @@ impl<'tmp> TempProject<'tmp> {
                 write!(cargo_toml, "{om_serialized}")?;
             }
 
-            // if build script is specified in the original Cargo.toml (from links or build) remove it as we do not need
-            // it for checking dependencies
+            // if build script is specified in the original Cargo.toml (from links or build)
+            // remove it as we do not need it for checking dependencies
             if om.package.contains_key("links") {
                 om.package.remove("links");
                 let om_serialized = ::toml::to_string(&om).expect("Cannot format as toml file");
@@ -419,7 +420,8 @@ impl<'tmp> TempProject<'tmp> {
             None => {
                 // If the version_req cannot be found use the version
                 // this happens when we use a git repository as a dependency, without specifying
-                // the version in Cargo.toml, preventing us from needing an unwrap below in the warn
+                // the version in Cargo.toml, preventing us from needing an unwrap below in the
+                // warn
                 let ver_req = match version_req {
                     Some(v_r) => format!("{v_r}"),
                     None => format!("{version}"),
@@ -434,7 +436,7 @@ impl<'tmp> TempProject<'tmp> {
                     query_result[0].version()
                 ))?;
 
-                //this returns the latest version
+                // this returns the latest version
                 &query_result[0]
             }
         };
@@ -497,8 +499,8 @@ impl<'tmp> TempProject<'tmp> {
         for dep_key in dep_keys {
             // this, by brute force, allows a user to exclude a dependency by not writing
             // it to the temp project's manifest
-            // In short this allows cargo to build the package with semver minor compatibilities issues
-            // https://github.com/rust-lang/cargo/issues/6584
+            // In short this allows cargo to build the package with semver minor
+            // compatibilities issues https://github.com/rust-lang/cargo/issues/6584
             // https://github.com/kbknapp/cargo-outdated/issues/230
             if self.options.exclude.contains(&dep_key) {
                 continue;
@@ -604,8 +606,9 @@ impl<'tmp> TempProject<'tmp> {
                                     };
                                     let retained =
                                         features_and_options(&summary).contains(feature.as_str());
-                                    // this unwrap should be safe it should only fail if we cannot get
-                                    // access to write to the terminal
+                                    // this unwrap should be safe it should only fail if we cannot
+                                    // get access to write to
+                                    // the terminal
                                     // if this fails it's a cargo (as a dependency) issue
                                     if !retained {
                                         self.warn(format!(
@@ -751,8 +754,9 @@ fn manifest_paths(elab: &ElaborateWorkspace<'_>) -> CargoResult<Vec<PathBuf>> {
             _ => None,
         };
 
-        // If there is a CARGO_HOME make sure we do not crawl the registry for more Cargo.toml files
-        // Otherwise add all Cargo.toml files to the manifest paths
+        // If there is a CARGO_HOME make sure we do not crawl the registry for more
+        // Cargo.toml files Otherwise add all Cargo.toml files to the manifest
+        // paths
         if pkg.root().starts_with(PathBuf::from(workspace_path))
             && (cargo_home_path.is_none()
                 || !pkg_path
@@ -770,7 +774,8 @@ fn manifest_paths(elab: &ElaborateWorkspace<'_>) -> CargoResult<Vec<PathBuf>> {
 
     // executed against a virtual manifest
     let workspace_path = elab.workspace.root().to_string_lossy();
-    // if cargo workspace is not explicitly used, the package itself would be a member
+    // if cargo workspace is not explicitly used, the package itself would be a
+    // member
     for member in elab.workspace.members() {
         let root_pkg_id = member.package_id();
         manifest_paths_recursive(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -45,10 +45,12 @@ pub struct Options {
     /// Space-separated list of features
     #[arg(long, use_value_delimiter = true)]
     pub features: Vec<String>,
-    /// Dependencies to not print in the output (comma separated or one per '--ignore' argument)
+    /// Dependencies to not print in the output (comma separated or one per
+    /// '--ignore' argument)
     #[arg(short, long, value_name = "DEPENDENCIES", use_value_delimiter = true)]
     pub ignore: Vec<String>,
-    /// Dependencies to exclude from building (comma separated or one per '--exclude' argument)
+    /// Dependencies to exclude from building (comma separated or one per
+    /// '--exclude' argument)
     #[arg(
         short = 'x',
         long,
@@ -56,7 +58,8 @@ pub struct Options {
         use_value_delimiter = true
     )]
     pub exclude: Vec<String>,
-    /// Path to the Cargo.toml file to use (Default to Cargo.toml in project root)
+    /// Path to the Cargo.toml file to use (Default to Cargo.toml in project
+    /// root)
     #[arg(short, long, value_name = "PATH")]
     pub manifest_path: Option<String>,
     /// Suppresses warnings
@@ -68,28 +71,33 @@ pub struct Options {
     /// The exit code to return on new versions found
     #[arg(long, value_name = "NUM", default_value_t = Default::default())]
     pub exit_code: i32,
-    /// Packages to inspect for updates (comma separated or one per --packages' argument)
+    /// Packages to inspect for updates (comma separated or one per --packages'
+    /// argument)
     #[arg(short, long, value_name = "PKGS", use_value_delimiter = true)]
     pub packages: Vec<String>,
     /// Package to treat as the root package
     #[arg(short, long)]
     pub root: Option<String>,
-    /// How deep in the dependency chain to search (Defaults to all dependencies)
+    /// How deep in the dependency chain to search (Defaults to all
+    /// dependencies)
     #[arg(short, long, value_name = "NUM")]
     pub depth: Option<i32>,
     /// Only check root dependencies (Equivalent to --depth=1)
     #[arg(short = 'R', long)]
     pub root_deps_only: bool,
-    /// Checks updates for all workspace members rather than only the root package
+    /// Checks updates for all workspace members rather than only the root
+    /// package
     #[arg(short, long)]
     pub workspace: bool,
     /// Ignores channels for latest updates
     #[arg(short, long)]
     pub aggressive: bool,
-    /// Ignore relative dependencies external to workspace and check root dependencies only
+    /// Ignore relative dependencies external to workspace and check root
+    /// dependencies only
     #[arg(short = 'e', long = "ignore-external-rel")]
     pub workspace_only: bool,
-    /// Run without accessing the network (useful for testing w/ local registries)
+    /// Run without accessing the network (useful for testing w/ local
+    /// registries)
     #[arg(short, long)]
     pub offline: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,11 @@ mod error;
 
 use std::collections::HashSet;
 
-use cargo::core::shell::Verbosity;
-use cargo::core::Workspace;
-use cargo::ops::needs_custom_http_transport;
-use cargo::util::important_paths::find_root_manifest_for_wd;
-use cargo::util::{CargoResult, CliError, Config};
+use cargo::{
+    core::{shell::Verbosity, Workspace},
+    ops::needs_custom_http_transport,
+    util::{important_paths::find_root_manifest_for_wd, CargoResult, CliError, Config},
+};
 
 use crate::{
     cargo_ops::{ElaborateWorkspace, TempProject},


### PR DESCRIPTION
Rollup of #348 and #349
Updates `toml` to v0.7

Trims down the CI and uses `just` as the command runner.