### PR TITLE
Notes MSRV is what is required to _run_

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         rust:
           - nightly
-          - 1.65.0 # MSRV
+          - 1.67.0 # MSRV
           - stable
 
     steps:
@@ -54,5 +54,9 @@ jobs:
         run: just lint
 
       - name: MSRV Check
-        if: ${{ matrix.rust == '1.65.0' }}
-        run: cargo check
+        if: ${{ matrix.rust == '1.67.0' }}
+        # Note we have to actually _run_ the application to check the MSRV.
+        # The standard `cargo check` may successfully build on an earlier 
+        # Rust, but cargo-oudated by not be able to successfully run in such
+        # environments.
+        run: cargo run -- outdated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+<a name="v0.13.0"></a>
+### v0.13.0 (2023-06-19)
+
+#### Changes
+
+* MSRV is now properly noted as 1.67.0. A note has been added that while you may be able to compile 
+  on an earlier version of Rust, the MSRV is what is required to _run_ `cargo-oudated` because it 
+  uses `cargo` internally.
+
+#### Maintenance
+
+* bump `strum` to v0.25
+
 <a name="v0.12.0"></a>
 ### v0.12.0 (2023-06-17)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2413,24 +2413,24 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "fe9f3bd7d2e45dcc5e265fbb88d6513e4747d8ef9444cf01a533119bce28a157"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-outdated"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "cargo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ tabwriter = "1.2.1"
 tempfile = "3"
 toml = "0.7.4"
 clap = { version = "4.1.4", features = ["derive"] }
-strum = { version = "0.24.1", features = ["derive"] }
+strum = { version = "0.25.0", features = ["derive"] }
 
 [dependencies.termcolor]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/kbknapp/cargo-outdated.git"
 description = "Cargo subcommand for displaying when dependencies are out of date"
-rust-version = "1.65.0" # MSRV
+rust-version = "1.67.0" # MSRV
 
 [[bin]]
 name = "cargo-outdated"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-outdated"
-version = "0.12.0"
+version = "0.13.0"
 authors = [
     "Kevin K. <kbknapp@gmail.com>",
     "Frederick Z. <frederick888@tsundere.moe>",

--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ Options:
     -r, --root ROOT             Package to treat as the root package
 ```
 
+## Minimum Supported Rust Version (MSRV)
+
+The MSRV of this crate is what is required to _run_ `cargo outdated`, you may be able to compile 
+`cargo outdated` itself on an earlier version of Rust. However, because `cargo oudated` uses 
+`cargo` internally, it requires a specific minimum version to run successfully.
+
+The current MSRV can be found in the `Cargo.toml` under the `package.rust-version` field.
+
 ## License
 
 `cargo-outdated` is released under the terms of either the MIT or Apache 2.0 license. See the LICENSE-MIT or LICENSE-APACHE file for the details.


### PR DESCRIPTION
Also bumps the minor version because we've changed the MSRV in the `Cargo.toml`.

Closes #355 