### PR TITLE
Bump tempfile due to RUSTSEC-2023-0018

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="v0.13.1"></a>
+### v0.13.1 (2023-06-19)
+
+#### Maintenance
+
+* bump `tempfile` due to [RUSTSEC-2023-0018](https://rustsec.org/advisories/RUSTSEC-2023-0018)
+
 <a name="v0.13.0"></a>
 ### v0.13.0 (2023-06-19)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "4.1.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88751f247234b1f73c8e8056fd835a0999b04e596e052302cb71186005dc4b27"
+checksum = "a8e0227bd284cd16105e8479602bb8af6bddcb800427e881c1feee4806310a31"
 dependencies = [
  "libc",
  "once_cell",
@@ -2123,15 +2123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,16 +2473,16 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
- "libc",
- "redox_syscall 0.2.16",
- "remove_dir_all",
- "winapi",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-outdated"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "cargo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde = {version="1.0.114", features = ["derive"]}
 serde_derive = "1.0.114"
 serde_json = "1.0.56"
 tabwriter = "1.2.1"
-tempfile = "3"
+tempfile = "3.6"
 toml = "0.7.4"
 clap = { version = "4.1.4", features = ["derive"] }
 strum = { version = "0.25.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-outdated"
-version = "0.13.0"
+version = "0.13.1"
 authors = [
     "Kevin K. <kbknapp@gmail.com>",
     "Frederick Z. <frederick888@tsundere.moe>",


### PR DESCRIPTION
After the last few PRs updating deps, this is the final RUSTSEC advisory that remained and was possible to eliminate by bumping `tempfile`'s minor version.

Closes #350 