### PR TITLE
feat: Support Cargo workspace inheritance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,15 +55,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
 dependencies = [
  "utf8parse",
 ]
@@ -331,9 +331,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.4"
+version = "4.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80672091db20273a15cf9fdd4e47ed43b5091ec9841bf4c6145c9dfbbcae09ed"
+checksum = "2686c4115cb0810d9a984776e197823d08ec94f176549a89a9efded477c456dc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.4"
+version = "4.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1458a1df40e1e2afebb7ab60ce55c1fa8f431146205aa5f4887e0b111c27636"
+checksum = "2e53afce1efce6ed1f633cf0e57612fe51db54a1ee4fd8f8503d078fe02d69ae"
 dependencies = [
  "anstream",
  "anstyle",
@@ -879,27 +879,27 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc02feb20ad313d52a450852f2005c2205d24f851e74d82b7807cbe12c371667"
+checksum = "311e2fa997be6560c564b070c5da2d56d038b645a94e1e5796d5d85a350da33c"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "gix-chunk"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7acf3bc6c4b91e8fb260086daf5e105ea3a6d913f5fd3318137f7e309d6e540"
+checksum = "39db5ed0fc0a2e9b1b8265993f7efdbc30379dec268f3b91b7af0c2de4672fdd"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6141b70cfb21255223e42f3379855037cbbe8673b58dd8318d2f09b516fad1"
+checksum = "bb49ab557a37b0abb2415bca2b10e541277dff0565deb5bd5e99fd95f93f51eb"
 dependencies = [
  "bstr",
 ]
@@ -1200,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "gix-quote"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d59489bff95b06dcdabe763b7266d3dc0a628cac1ac1caf65a7ca0a43eeae0"
+checksum = "3874de636c2526de26a3405b8024b23ef1a327bebf4845d770d00d48700b6a40"
 dependencies = [
  "bstr",
  "btoi",
@@ -1330,9 +1330,9 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ea5845b506c7728b9d89f4227cc369a5fc5a1d5b26c3add0f0d323413a3a60"
+checksum = "8d092b594c8af00a3a31fe526d363ee8a51a6f29d8496cdb991ed2f01ec0ec13"
 dependencies = [
  "bstr",
  "thiserror",
@@ -1792,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.54"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1833,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.88"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",

--- a/src/cargo_ops/mod.rs
+++ b/src/cargo_ops/mod.rs
@@ -8,29 +8,34 @@ pub use self::{elaborate_workspace::ElaborateWorkspace, pkg_status::*, temp_proj
 
 /// A continent struct for quick parsing and manipulating manifest
 #[derive(Debug, serde_derive::Serialize, serde_derive::Deserialize)]
+#[serde(rename_all = "kebab-case")]
 struct Manifest {
-    #[serde(rename = "cargo-features", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cargo_features: Option<Value>,
-    pub package: Table,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub package: Option<Table>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dependencies: Option<Table>,
-    #[serde(rename = "dev-dependencies", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dev_dependencies: Option<Table>,
-    #[serde(rename = "build-dependencies", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub build_dependencies: Option<Table>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub lib: Option<Table>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<Vec<Table>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace: Option<Table>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<Table>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub features: Option<Value>,
 }
 
 impl Manifest {
-    pub fn name(&self) -> String {
-        match self.package["name"] {
-            Value::String(ref name) => name.clone(),
+    pub fn name(&self) -> Option<String> {
+        match self.package.as_ref()?["name"] {
+            Value::String(ref name) => Some(name.clone()),
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
Virtual workspaces are generally less special now. Logging coverage has increased where it was useful during debugging. Switching to [`Path::strip_prefix`](https://doc.rust-lang.org/std/path/struct.Path.html#method.strip_prefix) from substrings using [`Path::to_str_lossy`](https://doc.rust-lang.org/std/path/struct.Path.html#method.to_str_lossy) has fixed possible confusion when temporary paths are long. Cargo `&Package` values are carried around longer now so that the user doesn't have to write explicit `lib` tables into their `Cargo.toml` files to avoid warnings.

Fixes kbknapp/cargo-outdated#325. 