### PR TITLE
use serde macro via serde crate instead of serde_derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,6 @@ dependencies = [
  "pretty_assertions",
  "semver",
  "serde",
- "serde_derive",
  "serde_json",
  "strum",
  "tabwriter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ env_logger = "0.10.0"
 git2-curl = "0.18.0"
 semver = "1.0.0"
 serde = {version="1.0.114", features = ["derive"]}
-serde_derive = "1.0.114"
 serde_json = "1.0.56"
 tabwriter = "1.2.1"
 tempfile = "3.6"

--- a/src/cargo_ops/mod.rs
+++ b/src/cargo_ops/mod.rs
@@ -7,7 +7,7 @@ mod temp_project;
 pub use self::{elaborate_workspace::ElaborateWorkspace, pkg_status::*, temp_project::TempProject};
 
 /// A continent struct for quick parsing and manipulating manifest
-#[derive(Debug, serde_derive::Serialize, serde_derive::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct Manifest {
     #[serde(rename = "cargo-features", skip_serializing_if = "Option::is_none")]
     pub cargo_features: Option<Value>,


### PR DESCRIPTION
`serde`'s macros could be used via `serde` crate as its `derive` feature is enabled.