### PR TITLE
chore: bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="v0.16.0"></a>
+
+### v0.16.0 (2024-12-07)
+
+#### Changes
+
+* MSRV is now as 1.81.0
+
+#### Maintenance
+
+* Update `cargo` and other dependencies to get project building again. ([#403](https://github.com/kbknapp/cargo-outdated/pull/403))
+
 <a name="v0.15.0"></a>
 ### v0.15.0 (2024-02-26)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-outdated"
-version = "0.15.0"
+version = "0.16.0"
 authors = [
     "Kevin K. <kbknapp@gmail.com>",
     "Frederick Z. <frederick888@tsundere.moe>",


### PR DESCRIPTION
Once this merges we can release v0.16.0