### PR TITLE
CI Updates

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -29,9 +29,9 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - name: Cache Builds
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Remove rust-toolchain.toml
         # contains nightly & linters/formatters
         shell: bash
@@ -56,9 +56,9 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - name: Cache Builds
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Remove rust-toolchain.toml
         # contains nightly & linters/formatters
         shell: bash
@@ -83,9 +83,9 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - name: Cache Builds
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Remove rust-toolchain.toml
         # contains nightly & linters/formatters
         shell: bash

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Cache Builds
         uses: Swatinem/rust-cache@v2
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Remove rust-toolchain.toml
         # contains nightly & linters/formatters
         shell: bash
@@ -58,7 +58,7 @@ jobs:
       - name: Cache Builds
         uses: Swatinem/rust-cache@v2
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Remove rust-toolchain.toml
         # contains nightly & linters/formatters
         shell: bash
@@ -85,7 +85,7 @@ jobs:
       - name: Cache Builds
         uses: Swatinem/rust-cache@v2
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Remove rust-toolchain.toml
         # contains nightly & linters/formatters
         shell: bash

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -25,15 +25,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
       - name: Cache Builds
         uses: Swatinem/rust-cache@v1
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Remove rust-toolchain.toml
+        # contains nightly & linters/formatters
+        shell: bash
+        run: rm -f rust-toolchain.toml
       - name: Compile
         run: cargo test --no-run ${{ env.FLAGS }}
       - name: Test
@@ -50,15 +52,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
       - name: Cache Builds
         uses: Swatinem/rust-cache@v1
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Remove rust-toolchain.toml
+        # contains nightly & linters/formatters
+        shell: bash
+        run: rm -f rust-toolchain.toml
       - name: Compile
         run: cargo test --no-run ${{ env.FLAGS }}
       - name: Test
@@ -75,15 +79,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
       - name: Cache Builds
         uses: Swatinem/rust-cache@v1
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Remove rust-toolchain.toml
+        # contains nightly & linters/formatters
+        shell: bash
+        run: rm -f rust-toolchain.toml
       - name: Compile
         run: cargo build ${{ env.FLAGS }}
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,29 +21,17 @@ jobs:
             rust: stable
             target: x86_64-pc-windows-msvc
           - os: windows-latest
-            rust: beta
-            target: x86_64-pc-windows-msvc
-          - os: windows-latest
             rust: stable
-            target: x86_64-pc-windows-gnu
-          - os: windows-latest
-            rust: beta
             target: x86_64-pc-windows-gnu
 
           # macOS x86_64
           - os: macos-15-intel
             rust: stable
             target: x86_64-apple-darwin
-          - os: macos-15-intel
-            rust: beta
-            target: x86_64-apple-darwin
 
           # macOS ARM64 (Apple Silicon)
           - os: macos-latest
             rust: stable
-            target: aarch64-apple-darwin
-          - os: macos-latest
-            rust: beta
             target: aarch64-apple-darwin
 
           # Linux x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,13 @@ jobs:
       - name: Install Just
         run: cargo install just cargo-nextest
 
-      - name: Install linker
+      - name: Install MinGW
         if: matrix.target == 'x86_64-pc-windows-gnu'
-        uses: egor-tensin/setup-mingw@v2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          install: mingw-w64-x86_64-gcc
+          update: true
 
       - name: OpenSSL Libs
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,31 +15,53 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        rust: [stable, beta]
-        os: [windows-latest, macOS-latest, ubuntu-latest]
-        target:
-          - x86_64-pc-windows-msvc
-          - x86_64-pc-windows-gnu
-          - x86_64-unknown-linux-gnu
-          - x86_64-apple-darwin
-        exclude:
-          # Exclude combinations that don't make sense
+        include:
+          # Windows x86_64
           - os: windows-latest
-            target: x86_64-apple-darwin
+            rust: stable
+            target: x86_64-pc-windows-msvc
           - os: windows-latest
-            target: x86_64-unknown-linux-gnu
-          - os: macos-latest
+            rust: beta
             target: x86_64-pc-windows-msvc
-          - os: macos-latest
+          - os: windows-latest
+            rust: stable
             target: x86_64-pc-windows-gnu
-          - os: macos-latest
-            target: x86_64-unknown-linux-gnu
-          - os: ubuntu-latest
-            target: x86_64-pc-windows-msvc
-          - os: ubuntu-latest
+          - os: windows-latest
+            rust: beta
             target: x86_64-pc-windows-gnu
-          - os: ubuntu-latest
+
+          # macOS x86_64
+          - os: macos-15-intel
+            rust: stable
             target: x86_64-apple-darwin
+          - os: macos-15-intel
+            rust: beta
+            target: x86_64-apple-darwin
+
+          # macOS ARM64 (Apple Silicon)
+          - os: macos-latest
+            rust: stable
+            target: aarch64-apple-darwin
+          - os: macos-latest
+            rust: beta
+            target: aarch64-apple-darwin
+
+          # Linux x86_64
+          - os: ubuntu-latest
+            rust: stable
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            rust: beta
+            target: x86_64-unknown-linux-gnu
+
+          # Linux aarch64
+          - os: ubuntu-24.04-arm
+            rust: stable
+            target: aarch64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            rust: beta
+            target: aarch64-unknown-linux-gnu
+
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install rust
@@ -47,21 +69,27 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
+
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Remove rust-toolchain.toml
         # contains nightly & linters/formatters
         shell: bash
         run: rm -f rust-toolchain.toml
+
       - name: Install Just
         run: cargo install just cargo-nextest
+
       - name: Install linker
         if: matrix.target == 'x86_64-pc-windows-gnu'
         uses: egor-tensin/setup-mingw@v2
+
       - name: OpenSSL Libs
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install libssl-dev
+
       - name: Test
         run: just test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Remove rust-toolchain.toml
         # contains nightly & linters/formatters

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.target }}
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Remove rust-toolchain.toml
         # contains nightly & linters/formatters
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Remove rust-toolchain.toml
+        # contains nightly & linters/formatters
+        shell: bash
+        run: rm -f rust-toolchain.toml
       - name: Install Just
         run: cargo install just cargo-nextest
       - name: Install linker

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,12 +9,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Remove rust-toolchain.toml
+        # contains nightly & linters/formatters
+        shell: bash
+        run: rm -f rust-toolchain.toml
+
       - name: Install stable
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build cargo-outdated
         run: |
@@ -63,13 +64,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Remove rust-toolchain.toml
+        # contains nightly & linters/formatters
+        run: rm -f rust-toolchain.toml
+
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
 
       - name: Install musl
         if: contains(matrix.target, 'linux-musl')
@@ -115,12 +117,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Remove rust-toolchain.toml
+        # contains nightly & linters/formatters
+        run: rm -f rust-toolchain.toml
+
       - name: Install Rust stable
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Create Cargo.lock
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ jobs:
   create-windows-binaries:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Remove rust-toolchain.toml
         # contains nightly & linters/formatters
@@ -62,7 +62,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Remove rust-toolchain.toml
         # contains nightly & linters/formatters
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Remove rust-toolchain.toml
         # contains nightly & linters/formatters

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,12 +47,16 @@ jobs:
   create-unix-binaries:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-latest]
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
-          - os: macos-latest
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+          - os: macos-15-intel
             target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,17 @@ on:
       - "v*.*.*"
 jobs:
   create-windows-binaries:
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        os: [windows-latest, windows-11-arm]
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
+
+    runs-on: ${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -32,8 +42,7 @@ jobs:
         id: package
         shell: bash
         run: |
-          ARCHIVE_TARGET="x86_64-pc-windows-msvc"
-          ARCHIVE_NAME="cargo-outdated-${{ steps.tagName.outputs.tag }}-$ARCHIVE_TARGET"
+          ARCHIVE_NAME="cargo-outdated-${{ steps.tagName.outputs.tag }}-${{ matrix.target }}"
           ARCHIVE_FILE="${ARCHIVE_NAME}.zip"
           7z a ${ARCHIVE_FILE} ./target/release/cargo-outdated.exe
           echo "file=${ARCHIVE_FILE}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
         id: tagName
         run: |
           VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
-          echo "::set-output name=tag::$VERSION"
+          echo "tag=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Build package
         id: package
@@ -35,8 +35,8 @@ jobs:
           ARCHIVE_NAME="cargo-outdated-${{ steps.tagName.outputs.tag }}-$ARCHIVE_TARGET"
           ARCHIVE_FILE="${ARCHIVE_NAME}.zip"
           7z a ${ARCHIVE_FILE} ./target/release/cargo-outdated.exe
-          echo "::set-output name=file::${ARCHIVE_FILE}"
-          echo "::set-output name=name::${ARCHIVE_NAME}.zip"
+          echo "file=${ARCHIVE_FILE}" >> $GITHUB_OUTPUT
+          echo "name=${ARCHIVE_NAME}.zip" >> $GITHUB_OUTPUT
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -90,7 +90,7 @@ jobs:
         id: tagName
         run: |
           VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
-          echo "::set-output name=tag::$VERSION"
+          echo "tag=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Build package
         id: package
@@ -98,8 +98,8 @@ jobs:
           TAR_FILE=cargo-outdated-${{ steps.tagName.outputs.tag }}-${{ matrix.target }}
           cd target/${{ matrix.target }}/release
           tar -czvf $GITHUB_WORKSPACE/$TAR_FILE.tar.gz cargo-outdated
-          echo ::set-output "name=name::${TAR_FILE}"
-          echo ::set-output "name=file::${TAR_FILE}.tar.gz "
+          echo "name=${TAR_FILE}" >> $GITHUB_OUTPUT
+          echo "file=${TAR_FILE}.tar.gz" >> $GITHUB_OUTPUT
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -130,7 +130,7 @@ jobs:
         id: tagName
         run: |
           VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
-          echo "::set-output name=tag::$VERSION"
+          echo "tag=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Remove rust-toolchain.toml
         # contains nightly & linters/formatters
@@ -71,7 +71,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Remove rust-toolchain.toml
         # contains nightly & linters/formatters
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Remove rust-toolchain.toml
         # contains nightly & linters/formatters

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,10 +54,10 @@ jobs:
 
       - name: Clippy
         if: ${{ matrix.rust == 'stable' }}
-        # Need to re-add rustfmt clippy in the nightly toolchain for "just"
         run: |
-          rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt clippy
-          just lint
+          cargo clippy --all-targets -- -Dwarnings
+          cargo clippy --all-targets --no-default-features -- -Dwarnings
+          cargo clippy --all-targets --all-features -- -Dwarnings
 
       - name: MSRV Check
         if: ${{ matrix.rust == '1.84.0' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
           - stable
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Remove rust-toolchain.toml
         # contains nightly & linters/formatters

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Clippy
         if: ${{ matrix.rust == 'stable' }}
+        # Need to re-add rustfmt clippy in the nightly toolchain for "just"
         run: |
           rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt clippy
           just lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
           - stable
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Remove rust-toolchain.toml
         # contains nightly & linters/formatters
@@ -38,7 +38,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Spell Check
         uses: crate-ci/typos@master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,18 +23,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Remove rust-toolchain.toml
+        # contains nightly & linters/formatters
+        run: rm -f rust-toolchain.toml
+
       - name: OpenSSL Libs
         if: matrix.os == 'ubuntu-latest' && matrix.features == 'all'
         run: |
           sudo apt-get update
           sudo apt-get install libssl-dev
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          components: clippy, rustfmt
           toolchain: ${{ matrix.rust }}
-          override: true
+          components: clippy, rustfmt
 
       - uses: Swatinem/rust-cache@v1
 
@@ -47,11 +49,14 @@ jobs:
 
       - name: Check Formatting
         if: ${{ matrix.rust == 'nightly' }}
-        run: just fmt-check
+        run: |
+          just fmt-check
 
       - name: Clippy
         if: ${{ matrix.rust == 'stable' }}
-        run: just lint
+        run: |
+          rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt clippy
+          just lint
 
       - name: MSRV Check
         if: ${{ matrix.rust == '1.84.0' }}


### PR DESCRIPTION
Hi, thanks a lot for this project!

I use it in my own CI I like the fact you release pre-built binaries, however I was missing some platforms. So here's a PR to modernize the workflows and add 2 platforms. I hope you'll like it! 

Note: I think this PR is worth looking at commit by commit, at least at first.

## Changes

### Release artifacts

- Added `aarch64-apple-darwin` (macOS ARM64) and `aarch64-unknown-linux-musl` (Linux ARM64) release binaries
- Updated runners: `macos-15-intel` for Intel Macs, `macos-latest` for ARM64, `ubuntu-24.04-arm` for Linux ARM64

### CI improvements

- Refactored test matrix from {cartesian product + excludes} to explicit `include` list, making it easier to add new platforms
- Added ARM64 testing for macOS (`aarch64-apple-darwin`) and Linux (`aarch64-unknown-linux-gnu`)
- Fixed Windows MinGW setup by replacing deprecated `egor-tensin/setup-mingw@v2` with `msys2/setup-msys2@v2`

### Workflow modernization

- Replaced deprecated `set-output` commands with `$GITHUB_OUTPUT`
- Bumped `actions/checkout` to v4 and `Swatinem/rust-cache` to v2
- Migrated from `actions-rs/toolchain` (unmaintained) to `dtolnay/rust-toolchain` across all workflows
- Related: added `rust-toolchain.toml` removal in CI workflows to ensure matrix toolchain selection is respected
    - was implemented with `override` in `actions-rs/toolchain`, needs this removal with the standard dtolnay/rust-toolchain
    - a simple trick was needed in the `lint.yml` workflow around `just` because it requires nightly even when testing stable targets in the matrix

## Testing

### Release workflow

Tested the release workflow with the additional targets: check the Release v0.18.0-test created for demo purposes in my fork, on the branch `ci/macos-arm64`. It contains the targets I mentioned above. 

- [Release Workflow Run](https://github.com/graelo/cargo-outdated/actions/runs/19646472009)
- Release: <https://github.com/graelo/cargo-outdated/releases/latest>

<img width="1263" height="719" alt="image" src="https://github.com/user-attachments/assets/633d06c0-6ff5-41e0-8759-40a3b1287ff1" />


### CI workflows

Tested the CI workflows on my fork with one additional commit branch on branch `ci/macos-arm64-exercise` - all builds and tests succeeded.

- [CI Workflow Run](https://github.com/graelo/cargo-outdated/actions/runs/19646625492)
- [CI-PR Workflow Run](https://github.com/graelo/cargo-outdated/actions/runs/19646624850)
- [Link Workflow Run](https://github.com/graelo/cargo-outdated/actions/runs/19646624926)

<img width="1325" height="777" alt="image" src="https://github.com/user-attachments/assets/b14b9cef-f50e-4bef-b232-8577f4197380" />

<img width="1256" height="737" alt="image" src="https://github.com/user-attachments/assets/e7b2f560-6d5e-4c9a-95a5-4d7bff645544" />

<img width="1227" height="620" alt="image" src="https://github.com/user-attachments/assets/067cb82f-a9fc-4c27-9762-4359b875b2ae" />

