### PR TITLE
fix(registry): handle Poll::Pending from sparse registry source queries

### DIFF
--- a/src/cargo_ops/temp_project.rs
+++ b/src/cargo_ops/temp_project.rs
@@ -398,14 +398,19 @@ impl<'tmp> TempProject<'tmp> {
             if !source_id.is_crates_io() && !source_id.is_sparse() {
                 source.invalidate_cache();
             }
-            source.block_until_ready()?;
             let dependency = Dependency::parse(name, None, source_id)?;
-            let query_result = match source.query_vec(&dependency, QueryKind::Exact)? {
-                Poll::Ready(query_result) => query_result,
-                Poll::Pending => {
-                    // querying private registry might fail / timeout, but let's just report an
-                    // error here instead of panicking
-                    anyhow::bail!("Querying source was unexpectedly pending")
+            // Query the source using the same poll loop pattern as cargo itself:
+            // https://github.com/rust-lang/cargo/blob/60400187f/src/cargo/core/resolver/errors.rs#L479-L488
+            //
+            // Sources (especially sparse registries) may return Poll::Pending on
+            // the first query to initiate an async fetch. Calling
+            // block_until_ready() drives the pending I/O to completion so the
+            // next query returns Poll::Ready.
+            let query_result = loop {
+                match source.query_vec(&dependency, QueryKind::Exact) {
+                    Poll::Ready(Ok(result)) => break result,
+                    Poll::Ready(Err(e)) => return Err(e),
+                    Poll::Pending => source.block_until_ready()?,
                 }
             };
             let mut query_result = query_result


### PR DESCRIPTION
# Issue

**Title:** `cargo outdated` panics with sparse private registries: "Source should be ready"

## Summary

`cargo outdated` panics (v0.17.0) or bails (v0.18.0) when used with a project that depends on a sparse private registry.

## Details

When querying a sparse registry source, `source.query_vec()` returns `Poll::Pending` on the first call because sparse registries (`HttpRegistry`) fetch package metadata on-demand via HTTP. The first call initiates the async request and returns `Pending` — the data isn't available until `block_until_ready()` is called to drive the HTTP response to completion.

The current code in `find_update()` calls `block_until_ready()` once *before* `query_vec()`, which is a no-op for sparse registries since no requests are in flight yet. When `query_vec()` then returns `Poll::Pending`, it is treated as a fatal error.

Cargo itself handles this with a poll loop:
https://github.com/rust-lang/cargo/blob/60400187f/src/cargo/core/resolver/errors.rs#L479-L488

## Steps to Reproduce

1. Configure a sparse private registry in `~/.cargo/config.toml`:
   ```toml
   [registries.my-registry]
   index = "sparse+https://my-registry.example.com/crates/cargo/"
   ```
2. Have a project with a dependency from that registry
3. Run `cargo outdated`

### v0.17.0
```
thread 'main' panicked at src/cargo_ops/temp_project.rs:404:18:
Source should be ready
```

### v0.18.0
```
Error: Querying source was unexpectedly pending
```

## Expected Behavior

`cargo outdated` should query the sparse registry successfully and report outdated dependencies.

---

# PR

**Title:** `fix: handle Poll::Pending from sparse registry source queries`

## Summary

- Use cargo's poll loop pattern to correctly handle `Poll::Pending` from sparse registry sources
- Remove redundant `block_until_ready()` call that was a no-op for sparse registries

## Details

Sparse registries (`sparse+https://...`) fetch package metadata on-demand via HTTP. The first
`query_vec()` call initiates the request and returns `Poll::Pending`. The fix replaces the
single query + bail with the same poll loop cargo itself uses:

https://github.com/rust-lang/cargo/blob/60400187f/src/cargo/core/resolver/errors.rs#L479-L488

## Test plan

- [x] Tested locally against a project with sparse private registry dependencies
- [x] `just ci` passes
